### PR TITLE
Rc/v0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Create Release
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      output1: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get current date
+        id: current_date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }} (${{ steps.current_date.outputs.date }})
+          body_path: ./RELEASENOTES.md
+          draft: true
+          prerelease: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.14.x, 1.15.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test
+        run: go test ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# [v0.2.0](https://github.com/nervosnetwork/ckb-bitpie-sdk/compare/v0.1.0...v0.2.0) (2020-11-25)
+
+
+### Bug Fixes
+
+* [#5](https://github.com/nervosnetwork/ckb-sdk-go/pull/5): fix nil pointer dereference on toCellWithStatus function
+* [#7](https://github.com/nervosnetwork/ckb-sdk-go/pull/7): fix tx fee calculation bug
+
+
+### Features
+
+* [#6](https://github.com/nervosnetwork/ckb-sdk-go/pull/6): support ckb indexer
+* [#8](https://github.com/nervosnetwork/ckb-sdk-go/pull/8): support ckb indexer on payment
+* [#9](https://github.com/nervosnetwork/ckb-sdk-go/pull/9): add OccupiedCapacity function
+* [#10](https://github.com/nervosnetwork/ckb-sdk-go/pull/10): support generate and parse short acp address

--- a/README.md
+++ b/README.md
@@ -463,52 +463,6 @@ import (
 )
 
 func main() {
-	client, err := rpc.Dial("http://127.0.0.1:8114")
-	if err != nil {
-		log.Fatalf("create rpc client error: %v", err)
-	}
-
-	key, err := secp256k1.HexToKey(PRIVATE_KEY)
-	if err != nil {
-		log.Fatalf("import private key error: %v", err)
-	}
-
-	pay, err := payment.NewPayment("ckt1qyqwmndf2yl6qvxwgvyw9yj95gkqytgygwasdjf6hm",
-		"ckt1qyqt705jmfy3r7jlvg88k87j0sksmhgduazq7x5l8k", 100000000000, 1000, false)
-	if err != nil {
-		log.Fatalf("create payment error: %v", err)
-	}
-
-	_, err = pay.GenerateTx(client)
-	if err != nil {
-		log.Fatalf("create transaction error: %v", err)
-	}
-
-	_, err = pay.Sign(key)
-	if err != nil {
-		log.Fatalf("sign transaction error: %v", err)
-	}
-
-	hash, err := pay.Send(client)
-
-	fmt.Println(hash)
-}
-```
-#### 6.1. Payment With Ckb-Indexer
-
-```go
-package main
-
-import (
-	"fmt"
-	"log"
-
-	"github.com/nervosnetwork/ckb-sdk-go/crypto/secp256k1"
-	"github.com/nervosnetwork/ckb-sdk-go/payment"
-	"github.com/nervosnetwork/ckb-sdk-go/rpc"
-)
-
-func main() {
 	client, err := rpc.DialWithIndexer("http://localhost:8114", "http://localhost:8116")
 	if err != nil {
 		log.Fatalf("create rpc client error: %v", err)

--- a/README.md
+++ b/README.md
@@ -78,14 +78,16 @@ func main() {
 	})
 	tx.OutputsData = [][]byte{{}, {}}
 
-	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, []*types.Cell{
+	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, []*types.CellInput{
 		{
-			OutPoint: &types.OutPoint{
-				TxHash: types.HexToHash("0x8e6d818c6e07e6cbd9fca51294030494ee23dc388d7f5276ba50b938d02cc015"),
-				Index:  1,
-			},
-		},
+            Since: 0,
+            PreviousOutput: &types.OutPoint{
+                TxHash: types.HexToHash("0x8e6d818c6e07e6cbd9fca51294030494ee23dc388d7f5276ba50b938d02cc015"),
+                Index: 1,
+            },
+        },
 	})
+
 	if err != nil {
 		log.Fatalf("add inputs to transaction error: %v", err)
 	}
@@ -156,15 +158,17 @@ func main() {
 	})
 	tx.OutputsData = [][]byte{{}}
 
-	groupB, witnessArgsB, err := transaction.AddInputsForTransaction(tx, []*types.Cell{
+	groupB, witnessArgsB, err := transaction.AddInputsForTransaction(tx, []*types.CellInput{
 		{
-			OutPoint: &types.OutPoint{
+			Since: 0,
+			PreviousOutput: &types.OutPoint{
 				TxHash: types.HexToHash("0xf56d73acbe235889e726366aa4fa09b3f0b51138c294645bb30912fb872837a5"),
 				Index:  0,
 			},
 		},
-		{
-			OutPoint: &types.OutPoint{
+		{   
+			Since: 0,
+			PreviousOutput: &types.OutPoint{
 				TxHash: types.HexToHash("0x8e6d818c6e07e6cbd9fca51294030494ee23dc388d7f5276ba50b938d02cc015"),
 				Index:  0,
 			},
@@ -174,9 +178,10 @@ func main() {
 		log.Fatalf("add inputs to transaction error: %v", err)
 	}
 
-	groupA, witnessArgsA, err := transaction.AddInputsForTransaction(tx, []*types.Cell{
-		{
-			OutPoint: &types.OutPoint{
+	groupA, witnessArgsA, err := transaction.AddInputsForTransaction(tx, []*types.CellInput{
+		{ 
+			Since: 0,
+			PreviousOutput: &types.OutPoint{
 				TxHash: types.HexToHash("0xf56d73acbe235889e726366aa4fa09b3f0b51138c294645bb30912fb872837a5"),
 				Index:  1,
 			},
@@ -260,15 +265,17 @@ func main() {
 	})
 	tx.OutputsData = [][]byte{{}, {}}
 
-	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, []*types.Cell{
-		{
-			OutPoint: &types.OutPoint{
+	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, []*types.CellInput{
+		{   
+			Since: 0,
+			PreviousOutput: &types.OutPoint{
 				TxHash: types.HexToHash("0xccb33a76b5322ff2841511ef10606b6bb207f6eef5a687f14f8c7fa5da8a7cb2"),
 				Index:  0,
 			},
 		},
-		{
-			OutPoint: &types.OutPoint{
+		{   
+            Since: 0,
+			PreviousOutput: &types.OutPoint{
 				TxHash: types.HexToHash("0x06a49393423c1be0a48d422fa60951bdb847d56753915f321c26906a6ba1dd8a"),
 				Index:  0,
 			},
@@ -349,9 +356,10 @@ func main() {
 	})
 	tx.OutputsData = [][]byte{{}, {}}
 
-	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, []*types.Cell{
-		{
-			OutPoint: &types.OutPoint{
+	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, []*types.CellInput{
+		{   
+            Since: 0,
+			PreviousOutput: &types.OutPoint{
 				TxHash: types.HexToHash("0xcb905a3b304b23200225def794c4ce165d93eead77197724680b4ec067b43803"),
 				Index:  0,
 			},
@@ -362,8 +370,9 @@ func main() {
 	}
 
 	group1, witnessArgs1, err := transaction.AddInputsForTransaction(tx, []*types.Cell{
-		{
-			OutPoint: &types.OutPoint{
+		{   
+            Since: 0,
+			PreviousOutput: &types.OutPoint{
 				TxHash: types.HexToHash("0xcb905a3b304b23200225def794c4ce165d93eead77197724680b4ec067b43803"),
 				Index:  1,
 			},
@@ -465,7 +474,53 @@ func main() {
 	}
 
 	pay, err := payment.NewPayment("ckt1qyqwmndf2yl6qvxwgvyw9yj95gkqytgygwasdjf6hm",
-		"ckt1qyqt705jmfy3r7jlvg88k87j0sksmhgduazq7x5l8k", 100000000000, 1000)
+		"ckt1qyqt705jmfy3r7jlvg88k87j0sksmhgduazq7x5l8k", 100000000000, 1000, false)
+	if err != nil {
+		log.Fatalf("create payment error: %v", err)
+	}
+
+	_, err = pay.GenerateTx(client)
+	if err != nil {
+		log.Fatalf("create transaction error: %v", err)
+	}
+
+	_, err = pay.Sign(key)
+	if err != nil {
+		log.Fatalf("sign transaction error: %v", err)
+	}
+
+	hash, err := pay.Send(client)
+
+	fmt.Println(hash)
+}
+```
+#### 6.1. Payment With Ckb-Indexer
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/nervosnetwork/ckb-sdk-go/crypto/secp256k1"
+	"github.com/nervosnetwork/ckb-sdk-go/payment"
+	"github.com/nervosnetwork/ckb-sdk-go/rpc"
+)
+
+func main() {
+	client, err := rpc.DialWithIndexer("http://localhost:8114", "http://localhost:8116")
+	if err != nil {
+		log.Fatalf("create rpc client error: %v", err)
+	}
+
+	key, err := secp256k1.HexToKey(PRIVATE_KEY)
+	if err != nil {
+		log.Fatalf("import private key error: %v", err)
+	}
+
+	pay, err := payment.NewPayment("ckt1qyqwmndf2yl6qvxwgvyw9yj95gkqytgygwasdjf6hm",
+		"ckt1qyqt705jmfy3r7jlvg88k87j0sksmhgduazq7x5l8k", 100000000000, 1000, true)
 	if err != nil {
 		log.Fatalf("create payment error: %v", err)
 	}
@@ -535,9 +590,10 @@ func main() {
 		log.Fatalf("add output error: %v", err)
 	}
 
-	group, witnessArgs, err := transaction.AddInputsForTransaction(deposit.Transaction, []*types.Cell{
-		{
-			OutPoint: &types.OutPoint{
+	group, witnessArgs, err := transaction.AddInputsForTransaction(deposit.Transaction, []*types.CellInput{
+		{   
+            Since: 0,
+			PreviousOutput: &types.OutPoint{
 				TxHash: types.HexToHash("0xaa10f51bc6ee60e851d17e3fffefc950d6dc1d2cd77e15699c3da5e837219764"),
 				Index:  1,
 			},
@@ -623,9 +679,10 @@ func main() {
 		log.Fatalf("add output error: %v", err)
 	}
 
-	group, witnessArgs, err := transaction.AddInputsForTransaction(withdraw.Transaction, []*types.Cell{
-		{
-			OutPoint: &types.OutPoint{
+	group, witnessArgs, err := transaction.AddInputsForTransaction(withdraw.Transaction, []*types.CellInput{
+		{   
+            Since: 0,
+			PreviousOutput: &types.OutPoint{
 				TxHash: types.HexToHash("0xc8cfe3d09b0a50fd2df3bd79dbadca23b7eb1f58087942d7266abea93459fce1"),
 				Index:  1,
 			},

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,15 @@
+# [v0.2.0](https://github.com/nervosnetwork/ckb-bitpie-sdk/compare/v0.1.0...v0.2.0) (2020-11-25)
+
+
+### Bug Fixes
+
+* [#5](https://github.com/nervosnetwork/ckb-sdk-go/pull/5): fix nil pointer dereference on toCellWithStatus function
+* [#7](https://github.com/nervosnetwork/ckb-sdk-go/pull/7): fix tx fee calculation bug
+
+
+### Features
+
+* [#6](https://github.com/nervosnetwork/ckb-sdk-go/pull/6): support ckb indexer
+* [#8](https://github.com/nervosnetwork/ckb-sdk-go/pull/8): support ckb indexer on payment
+* [#9](https://github.com/nervosnetwork/ckb-sdk-go/pull/9): add OccupiedCapacity function
+* [#10](https://github.com/nervosnetwork/ckb-sdk-go/pull/10): support generate and parse short acp address

--- a/address/address.go
+++ b/address/address.go
@@ -31,7 +31,7 @@ const (
 	CodeHashIndexAnyoneCanPay = "02"
 )
 
-var shortPayloadSupportedArgsLens = [3]int{20, 21, 22}
+var shortPayloadSupportedArgsLens = [2]int{20, 22}
 
 type ParsedAddress struct {
 	Mode   Mode
@@ -76,10 +76,8 @@ func Generate(mode Mode, script *types.Script) (string, error) {
 }
 
 func isShortPayloadSupportedArgsLen(argLen int) bool {
-	for _, l := range shortPayloadSupportedArgsLens {
-		if l == argLen {
-			return true
-		}
+	if argLen >= shortPayloadSupportedArgsLens[0] && argLen <= shortPayloadSupportedArgsLens[1] {
+		return true
 	}
 	return false
 }

--- a/address/address.go
+++ b/address/address.go
@@ -114,6 +114,16 @@ func Parse(address string) (*ParsedAddress, error) {
 				HashType: types.HashTypeType,
 				Args:     common.Hex2Bytes(payload[4:]),
 			}
+		} else if CodeHashIndexAnyoneCanPay == payload[2:4] {
+			script = types.Script{
+				HashType: types.HashTypeType,
+				Args:     common.Hex2Bytes(payload[4:]),
+			}
+			if hrp == (string)(Testnet) {
+				script.CodeHash = types.HexToHash(utils.AnyoneCanPayCodeHashOnAggron)
+			} else {
+				script.CodeHash = types.HexToHash(utils.AnyoneCanPayCodeHashOnLina)
+			}
 		} else {
 			script = types.Script{
 				CodeHash: types.HexToHash(transaction.SECP256K1_BLAKE160_MULTISIG_ALL_TYPE_HASH),

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -127,4 +127,124 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, script.CodeHash, mnAddress.Script.CodeHash)
 	assert.Equal(t, script.HashType, mnAddress.Script.HashType)
 	assert.Equal(t, script.Args, mnAddress.Script.Args)
+
+	t.Run("parse short payload acp address without minimum limit", func(t *testing.T) {
+		mAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnLina),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a"),
+		}
+
+		mParsedAddress, err := Parse("ckb1qypylv479ewscx3ms620sv34pgeuz6zagaaqvrugu7")
+		assert.Nil(t, err)
+		assert.Equal(t, Mainnet, mParsedAddress.Mode)
+		assert.Equal(t, TypeShort, mParsedAddress.Type)
+		assert.Equal(t, mAcpLock.CodeHash, mParsedAddress.Script.CodeHash)
+		assert.Equal(t, mAcpLock.HashType, mParsedAddress.Script.HashType)
+		assert.Equal(t, mAcpLock.Args, mParsedAddress.Script.Args)
+
+		tAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnAggron),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a"),
+		}
+
+		tParsedAddress, err := Parse("ckt1qypylv479ewscx3ms620sv34pgeuz6zagaaq3xzhsz")
+		assert.Nil(t, err)
+		assert.Equal(t, Testnet, tParsedAddress.Mode)
+		assert.Equal(t, TypeShort, tParsedAddress.Type)
+		assert.Equal(t, tAcpLock.CodeHash, tParsedAddress.Script.CodeHash)
+		assert.Equal(t, tAcpLock.HashType, tParsedAddress.Script.HashType)
+		assert.Equal(t, tAcpLock.Args, tParsedAddress.Script.Args)
+	})
+
+	t.Run("parse short payload acp address with ckb minimum limit", func(t *testing.T) {
+		mAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnLina),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c"),
+		}
+
+		mParsedAddress, err := Parse("ckb1qypylv479ewscx3ms620sv34pgeuz6zagaaqcehzz9g")
+		assert.Nil(t, err)
+		assert.Equal(t, Mainnet, mParsedAddress.Mode)
+		assert.Equal(t, TypeShort, mParsedAddress.Type)
+		assert.Equal(t, mAcpLock.CodeHash, mParsedAddress.Script.CodeHash)
+		assert.Equal(t, mAcpLock.HashType, mParsedAddress.Script.HashType)
+		assert.Equal(t, mAcpLock.Args, mParsedAddress.Script.Args)
+
+		tAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnAggron),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c"),
+		}
+
+		tParsedAddress, err := Parse("ckt1qypylv479ewscx3ms620sv34pgeuz6zagaaqc9q8fqw")
+		assert.Nil(t, err)
+		assert.Equal(t, Testnet, tParsedAddress.Mode)
+		assert.Equal(t, TypeShort, tParsedAddress.Type)
+		assert.Equal(t, tAcpLock.CodeHash, tParsedAddress.Script.CodeHash)
+		assert.Equal(t, tAcpLock.HashType, tParsedAddress.Script.HashType)
+		assert.Equal(t, tAcpLock.Args, tParsedAddress.Script.Args)
+	})
+
+	t.Run("parse short payload acp address with ckb minimum limit and udt minimum limit", func(t *testing.T) {
+		mAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnLina),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c01"),
+		}
+
+		mParsedAddress, err := Parse("ckb1qypylv479ewscx3ms620sv34pgeuz6zagaaqcqgzc5xlw")
+		assert.Nil(t, err)
+		assert.Equal(t, Mainnet, mParsedAddress.Mode)
+		assert.Equal(t, TypeShort, mParsedAddress.Type)
+		assert.Equal(t, mAcpLock.CodeHash, mParsedAddress.Script.CodeHash)
+		assert.Equal(t, mAcpLock.HashType, mParsedAddress.Script.HashType)
+		assert.Equal(t, mAcpLock.Args, mParsedAddress.Script.Args)
+
+		tAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnAggron),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c01"),
+		}
+
+		tParsedAddress, err := Parse("ckt1qypylv479ewscx3ms620sv34pgeuz6zagaaqcqgr072sz")
+		assert.Nil(t, err)
+		assert.Equal(t, Testnet, tParsedAddress.Mode)
+		assert.Equal(t, TypeShort, tParsedAddress.Type)
+		assert.Equal(t, tAcpLock.CodeHash, tParsedAddress.Script.CodeHash)
+		assert.Equal(t, tAcpLock.HashType, tParsedAddress.Script.HashType)
+		assert.Equal(t, tAcpLock.Args, tParsedAddress.Script.Args)
+	})
+
+	t.Run("parse full payload acp address with args more than 22 bytes", func(t *testing.T) {
+		mAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnLina),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c0101"),
+		}
+
+		mParsedAddress, err := Parse("ckb1qnfkjktl73ljn77q637judm4xux3y59c29qvvu8ywx90wy5c8g34gnajhch96rq68wrff7pjx59r8stgt4rh5rqpqy532xj3")
+		assert.Nil(t, err)
+		assert.Equal(t, Mainnet, mParsedAddress.Mode)
+		assert.Equal(t, TypeFull, mParsedAddress.Type)
+		assert.Equal(t, mAcpLock.CodeHash, mParsedAddress.Script.CodeHash)
+		assert.Equal(t, mAcpLock.HashType, mParsedAddress.Script.HashType)
+		assert.Equal(t, mAcpLock.Args, mParsedAddress.Script.Args)
+
+		tAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnAggron),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c0101"),
+		}
+
+		tParsedAddress, err := Parse("ckt1qs6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vnajhch96rq68wrff7pjx59r8stgt4rh5rqpqy2a9ak4")
+		assert.Nil(t, err)
+		assert.Equal(t, Testnet, tParsedAddress.Mode)
+		assert.Equal(t, TypeFull, tParsedAddress.Type)
+		assert.Equal(t, tAcpLock.CodeHash, tParsedAddress.Script.CodeHash)
+		assert.Equal(t, tAcpLock.HashType, tParsedAddress.Script.HashType)
+		assert.Equal(t, tAcpLock.Args, tParsedAddress.Script.Args)
+	})
 }

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -1,6 +1,7 @@
 package address
 
 import (
+	"github.com/nervosnetwork/ckb-sdk-go/utils"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -24,6 +25,91 @@ func TestGenerate(t *testing.T) {
 	tnAddress, err := Generate(Testnet, script)
 	assert.Nil(t, err)
 	assert.Equal(t, "ckt1qyqwmndf2yl6qvxwgvyw9yj95gkqytgygwasdjf6hm", tnAddress)
+
+	t.Run("generate short payload acp address without minimum limit", func(t *testing.T) {
+		mAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnLina),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a"),
+		}
+
+		mAddress, err := Generate(Mainnet, mAcpLock)
+		assert.Nil(t, err)
+		assert.Equal(t, "ckb1qypylv479ewscx3ms620sv34pgeuz6zagaaqvrugu7", mAddress)
+
+		tAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnAggron),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a"),
+		}
+		tAddress, err := Generate(Testnet, tAcpLock)
+		assert.Nil(t, err)
+		assert.Equal(t, "ckt1qypylv479ewscx3ms620sv34pgeuz6zagaaq3xzhsz", tAddress)
+	})
+
+	t.Run("generate short payload acp address with ckb minimum limit", func(t *testing.T) {
+		mAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnLina),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c"),
+		}
+
+		mAddress, err := Generate(Mainnet, mAcpLock)
+		assert.Nil(t, err)
+		assert.Equal(t, "ckb1qypylv479ewscx3ms620sv34pgeuz6zagaaqcehzz9g", mAddress)
+
+		tAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnAggron),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c"),
+		}
+		tAddress, err := Generate(Testnet, tAcpLock)
+		assert.Nil(t, err)
+		assert.Equal(t, "ckt1qypylv479ewscx3ms620sv34pgeuz6zagaaqc9q8fqw", tAddress)
+	})
+
+	t.Run("generate short payload acp address with ckb and udt minimum limit", func(t *testing.T) {
+		mAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnLina),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c01"),
+		}
+
+		mAddress, err := Generate(Mainnet, mAcpLock)
+		assert.Nil(t, err)
+		assert.Equal(t, "ckb1qypylv479ewscx3ms620sv34pgeuz6zagaaqcqgzc5xlw", mAddress)
+
+		tAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnAggron),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c01"),
+		}
+		tAddress, err := Generate(Testnet, tAcpLock)
+		assert.Nil(t, err)
+		assert.Equal(t, "ckt1qypylv479ewscx3ms620sv34pgeuz6zagaaqcqgr072sz", tAddress)
+	})
+
+	t.Run("generate full payload address when acp lock args is more than 22 bytes", func(t *testing.T) {
+		mAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnLina),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c0101"),
+		}
+
+		mAddress, err := Generate(Mainnet, mAcpLock)
+		assert.Nil(t, err)
+		assert.Equal(t, "ckb1qnfkjktl73ljn77q637judm4xux3y59c29qvvu8ywx90wy5c8g34gnajhch96rq68wrff7pjx59r8stgt4rh5rqpqy532xj3", mAddress)
+
+		tAcpLock := &types.Script{
+			CodeHash: types.HexToHash(utils.AnyoneCanPayCodeHashOnAggron),
+			HashType: types.HashTypeType,
+			Args:     common.FromHex("0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a0c0101"),
+		}
+
+		tAddress, err := Generate(Testnet, tAcpLock)
+		assert.Nil(t, err)
+		assert.Equal(t, "ckt1qs6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vnajhch96rq68wrff7pjx59r8stgt4rh5rqpqy2a9ak4", tAddress)
+	})
 }
 
 func TestParse(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,9 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847 h1:rtI0fD4oG/8eVokGVPYJEW1F88p1ZNgXiEIs9thEE4A=
@@ -108,6 +110,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce h1:X0jFYGnHemYDIW6jlc+fSI8f9Cg+jqCnClYP2WgZT/A=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
@@ -151,6 +154,7 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -1,0 +1,102 @@
+package indexer
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type Client interface {
+	// GetCells returns the live cells collection by the lock or type script.
+	GetCells(ctx context.Context, searchKey *SearchKey, order SearchOrder, limit uint64, afterCursor string) (*LiveCells, error)
+
+	// GetTransactions returns the transactions collection by the lock or type script.
+	GetTransactions(ctx context.Context, searchKey *SearchKey, order SearchOrder, limit uint64, afterCursor string) (*Transactions, error)
+
+	//GetTip returns the latest height processed by indexer
+	GetTip(ctx context.Context) (*TipHeader, error)
+
+	//GetCellsCapacity returns the live cells capacity by the lock or type script.
+	GetCellsCapacity(ctx context.Context, searchKey *SearchKey) (*Capacity, error)
+
+	// Close close client
+	Close()
+}
+
+type client struct {
+	c *rpc.Client
+}
+
+func Dial(url string) (Client, error) {
+	return DialContext(context.Background(), url)
+}
+
+func DialContext(ctx context.Context, url string) (Client, error) {
+	c, err := rpc.DialContext(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(c), nil
+}
+
+func NewClient(c *rpc.Client) Client {
+	return &client{c}
+}
+
+func (cli *client) Close() {
+	cli.c.Close()
+}
+
+func (cli *client) GetCells(ctx context.Context, searchKey *SearchKey, order SearchOrder, limit uint64, afterCursor string) (*LiveCells, error) {
+	var result liveCells
+	var err error
+	if afterCursor == "" {
+		err = cli.c.CallContext(ctx, &result, "get_cells", fromSearchKey(searchKey), order, hexutil.Uint64(limit))
+	} else {
+		err = cli.c.CallContext(ctx, &result, "get_cells", fromSearchKey(searchKey), order, hexutil.Uint64(limit), afterCursor)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return toLiveCells(result), err
+}
+
+func (cli *client) GetTransactions(ctx context.Context, searchKey *SearchKey, order SearchOrder, limit uint64, afterCursor string) (*Transactions, error) {
+	var result transactions
+	var err error
+	if afterCursor == "" {
+		err = cli.c.CallContext(ctx, &result, "get_transactions", fromSearchKey(searchKey), order, hexutil.Uint64(limit))
+	} else {
+		err = cli.c.CallContext(ctx, &result, "get_transactions", fromSearchKey(searchKey), order, hexutil.Uint64(limit), afterCursor)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return toTransactions(result), err
+}
+
+func (cli *client) GetTip(ctx context.Context) (*TipHeader, error) {
+	var result tipHeader
+	err := cli.c.CallContext(ctx, &result, "get_tip")
+	if err != nil {
+		return nil, err
+	}
+	return &TipHeader{
+		BlockHash:   result.BlockHash,
+		BlockNumber: uint64(result.BlockNumber),
+	}, nil
+}
+
+func (cli *client) GetCellsCapacity(ctx context.Context, searchKey *SearchKey) (*Capacity, error) {
+	var result capacity
+	err := cli.c.CallContext(ctx, &result, "get_cells_capacity", fromSearchKey(searchKey))
+	if err != nil {
+		return nil, err
+	}
+	return &Capacity{
+		Capacity:    uint64(result.Capacity),
+		BlockHash:   result.BlockHash,
+		BlockNumber: uint64(result.BlockNumber),
+	}, nil
+}

--- a/indexer/types.go
+++ b/indexer/types.go
@@ -1,0 +1,190 @@
+package indexer
+
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/nervosnetwork/ckb-sdk-go/types"
+)
+
+type ScriptType string
+type SearchOrder string
+type IoType string
+
+const (
+	ScriptTypeLock ScriptType = "lock"
+	ScriptTypeType ScriptType = "type"
+
+	SearchOrderAsc  SearchOrder = "asc"
+	SearchOrderDesc SearchOrder = "desc"
+
+	IOTypeIn  IoType = "input"
+	IOTypeOut IoType = "output"
+)
+
+type SearchKey struct {
+	Script     *types.Script `json:"script"`
+	ScriptType ScriptType    `json:"script_type"`
+	ArgsLen    uint          `json:"args_len,omitempty"`
+}
+
+type LiveCell struct {
+	BlockNumber uint64            `json:"block_number"`
+	OutPoint    *types.OutPoint   `json:"out_point"`
+	Output      *types.CellOutput `json:"output"`
+	OutputData  []byte            `json:"output_data"`
+	TxIndex     uint              `json:"tx_index"`
+}
+
+type LiveCells struct {
+	LastCursor string      `json:"last_cursor"`
+	Objects    []*LiveCell `json:"objects"`
+}
+
+type Transaction struct {
+	BlockNumber uint64     `json:"block_number"`
+	IoIndex     uint       `json:"io_index"`
+	IoType      IoType     `json:"io_type"`
+	TxHash      types.Hash `json:"tx_hash"`
+	TxIndex     uint       `json:"tx_index"`
+}
+
+type Transactions struct {
+	LastCursor string         `json:"last_cursor"`
+	Objects    []*Transaction `json:"objects"`
+}
+
+type TipHeader struct {
+	BlockHash   types.Hash `json:"block_hash"`
+	BlockNumber uint64     `json:"block_number"`
+}
+
+type Capacity struct {
+	Capacity    uint64     `json:"capacity"`
+	BlockHash   types.Hash `json:"block_hash"`
+	BlockNumber uint64     `json:"block_number"`
+}
+
+type capacity struct {
+	Capacity    hexutil.Uint64 `json:"capacity"`
+	BlockHash   types.Hash     `json:"block_hash"`
+	BlockNumber hexutil.Uint64 `json:"block_number"`
+}
+
+type tipHeader struct {
+	BlockHash   types.Hash     `json:"block_hash"`
+	BlockNumber hexutil.Uint64 `json:"block_number"`
+}
+
+type searchKey struct {
+	Script     *script      `json:"script"`
+	ScriptType ScriptType   `json:"script_type"`
+	ArgsLen    hexutil.Uint `json:"args_len,omitempty"`
+}
+
+type outPoint struct {
+	TxHash types.Hash   `json:"tx_hash"`
+	Index  hexutil.Uint `json:"index"`
+}
+
+type script struct {
+	CodeHash types.Hash           `json:"code_hash"`
+	HashType types.ScriptHashType `json:"hash_type"`
+	Args     hexutil.Bytes        `json:"args"`
+}
+
+type cellOutput struct {
+	Capacity hexutil.Uint64 `json:"capacity"`
+	Lock     *script        `json:"lock"`
+	Type     *script        `json:"type"`
+}
+
+type liveCells struct {
+	LastCursor string `json:"last_cursor"`
+	Objects    []struct {
+		BlockNumber hexutil.Uint64 `json:"block_number"`
+		OutPoint    *outPoint      `json:"out_point"`
+		Output      *cellOutput    `json:"output"`
+		OutputData  hexutil.Bytes  `json:"output_data"`
+		TxIndex     hexutil.Uint   `json:"tx_index"`
+	} `json:"objects"`
+}
+
+type transactions struct {
+	LastCursor string `json:"last_cursor"`
+	Objects    []struct {
+		BlockNumber hexutil.Uint64 `json:"block_number"`
+		IoIndex     hexutil.Uint   `json:"io_index"`
+		IoType      IoType         `json:"io_type"`
+		TxHash      types.Hash     `json:"tx_hash"`
+		TxIndex     hexutil.Uint   `json:"tx_index"`
+	} `json:"objects"`
+}
+
+func toTransactions(transactions transactions) *Transactions {
+	result := &Transactions{
+		LastCursor: transactions.LastCursor,
+	}
+	result.Objects = make([]*Transaction, len(transactions.Objects))
+	for i := 0; i < len(transactions.Objects); i++ {
+		transaction := transactions.Objects[i]
+		result.Objects[i] = &Transaction{
+			BlockNumber: uint64(transaction.BlockNumber),
+			IoIndex:     uint(transaction.IoIndex),
+			IoType:      transaction.IoType,
+			TxHash:      transaction.TxHash,
+			TxIndex:     uint(transaction.TxIndex),
+		}
+	}
+	return result
+}
+
+func toLiveCells(cells liveCells) *LiveCells {
+	result := &LiveCells{
+		LastCursor: cells.LastCursor,
+	}
+	result.Objects = make([]*LiveCell, len(cells.Objects))
+	for i := 0; i < len(cells.Objects); i++ {
+		cell := cells.Objects[i]
+		result.Objects[i] = &LiveCell{
+			BlockNumber: uint64(cell.BlockNumber),
+			OutPoint: &types.OutPoint{
+				TxHash: cell.OutPoint.TxHash,
+				Index:  uint(cell.OutPoint.Index),
+			},
+			OutputData: cell.OutputData,
+			TxIndex:    uint(cell.TxIndex),
+		}
+		result.Objects[i].Output = &types.CellOutput{
+			Capacity: uint64(cell.Output.Capacity),
+			Lock: &types.Script{
+				CodeHash: cell.Output.Lock.CodeHash,
+				HashType: cell.Output.Lock.HashType,
+				Args:     cell.Output.Lock.Args,
+			},
+		}
+		if cell.Output.Type != nil {
+			result.Objects[i].Output.Type = &types.Script{
+				CodeHash: cell.Output.Type.CodeHash,
+				HashType: cell.Output.Type.HashType,
+				Args:     cell.Output.Type.Args,
+			}
+		}
+	}
+	return result
+}
+
+func fromSearchKey(key *SearchKey) *searchKey {
+	result := &searchKey{
+		Script: &script{
+			CodeHash: key.Script.CodeHash,
+			HashType: key.Script.HashType,
+			Args:     key.Script.Args,
+		},
+		ScriptType: key.ScriptType,
+	}
+
+	if key.ArgsLen > 0 {
+		result.ArgsLen = hexutil.Uint(key.ArgsLen)
+	}
+
+	return result
+}

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -14,18 +14,16 @@ import (
 )
 
 type Payment struct {
-	From            *types.Script
-	To              *types.Script
-	Amount          uint64
-	Fee             uint64
-	UseIndexer      bool
-	group           []int
-	witnessArgs     *types.WitnessArgs
-	tx              *types.Transaction
-	fromBlockNumber uint64
+	From        *types.Script
+	To          *types.Script
+	Amount      uint64
+	Fee         uint64
+	group       []int
+	witnessArgs *types.WitnessArgs
+	tx          *types.Transaction
 }
 
-func NewPayment(from, to string, amount, fee uint64, fromBlockNumber uint64, useIndexer bool) (*Payment, error) {
+func NewPayment(from, to string, amount, fee uint64) (*Payment, error) {
 	fromAddress, err := address.Parse(from)
 	if err != nil {
 		return nil, fmt.Errorf("parse from address %s error: %v", from, err)
@@ -40,78 +38,15 @@ func NewPayment(from, to string, amount, fee uint64, fromBlockNumber uint64, use
 	}
 
 	return &Payment{
-		From:            fromAddress.Script,
-		To:              toAddress.Script,
-		Amount:          amount,
-		Fee:             fee,
-		fromBlockNumber: fromBlockNumber,
-		UseIndexer:      useIndexer,
+		From:   fromAddress.Script,
+		To:     toAddress.Script,
+		Amount: amount,
+		Fee:    fee,
 	}, nil
 }
 
 func (p *Payment) GenerateTx(client rpc.Client) (*types.Transaction, error) {
-	if p.UseIndexer {
-		return generateTxWithIndexer(client, p)
-	} else {
-		return generateTx(client, p)
-	}
-}
-
-func generateTx(client rpc.Client, p *Payment) (*types.Transaction, error) {
-	collector := utils.NewCellCollector(client, p.From, utils.NewCapacityCellProcessor(p.Amount+p.Fee), p.fromBlockNumber)
-
-	result, err := collector.Collect()
-	if err != nil {
-		return nil, fmt.Errorf("collect cell error: %v", err)
-	}
-
-	if result.Capacity < p.Amount+p.Fee {
-		return nil, fmt.Errorf("insufficient balance: %d", result.Capacity)
-	}
-
-	systemScripts, err := utils.NewSystemScripts(client)
-	if err != nil {
-		return nil, fmt.Errorf("load system script error: %v", err)
-	}
-
-	tx := transaction.NewSecp256k1SingleSigTx(systemScripts)
-	tx.Outputs = append(tx.Outputs, &types.CellOutput{
-		Capacity: p.Amount,
-		Lock:     p.To,
-	})
-	tx.OutputsData = [][]byte{{}}
-
-	if result.Capacity-p.Amount-p.Fee > 0 {
-		if result.Capacity-p.Amount-p.Fee >= 6100000000 {
-			tx.Outputs = append(tx.Outputs, &types.CellOutput{
-				Capacity: result.Capacity - p.Amount - p.Fee,
-				Lock:     p.From,
-			})
-			tx.OutputsData = [][]byte{{}, {}}
-		} else {
-			tx.Outputs[0].Capacity = result.Capacity - p.Fee
-		}
-	}
-	var inputs []*types.CellInput
-	for _, cell := range result.Cells {
-		input := &types.CellInput{
-			Since: 0,
-			PreviousOutput: &types.OutPoint{
-				TxHash: cell.OutPoint.TxHash,
-				Index:  cell.OutPoint.Index,
-			},
-		}
-		inputs = append(inputs, input)
-	}
-	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, inputs)
-	if err != nil {
-		return nil, fmt.Errorf("add inputs to transaction error: %v", err)
-	}
-
-	p.group = group
-	p.witnessArgs = witnessArgs
-	p.tx = tx
-	return tx, err
+	return generateTxWithIndexer(client, p)
 }
 
 func generateTxWithIndexer(client rpc.Client, p *Payment) (*types.Transaction, error) {

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -3,6 +3,7 @@ package payment
 import (
 	"context"
 	"fmt"
+	"github.com/nervosnetwork/ckb-sdk-go/indexer"
 
 	"github.com/nervosnetwork/ckb-sdk-go/address"
 	"github.com/nervosnetwork/ckb-sdk-go/crypto"
@@ -17,13 +18,14 @@ type Payment struct {
 	To              *types.Script
 	Amount          uint64
 	Fee             uint64
+	UseIndexer      bool
 	group           []int
 	witnessArgs     *types.WitnessArgs
 	tx              *types.Transaction
 	fromBlockNumber uint64
 }
 
-func NewPayment(from, to string, amount, fee uint64, fromBlockNumber uint64) (*Payment, error) {
+func NewPayment(from, to string, amount, fee uint64, fromBlockNumber uint64, useIndexer bool) (*Payment, error) {
 	fromAddress, err := address.Parse(from)
 	if err != nil {
 		return nil, fmt.Errorf("parse from address %s error: %v", from, err)
@@ -38,15 +40,24 @@ func NewPayment(from, to string, amount, fee uint64, fromBlockNumber uint64) (*P
 	}
 
 	return &Payment{
-		From:   fromAddress.Script,
-		To:     toAddress.Script,
-		Amount: amount,
-		Fee:    fee,
+		From:            fromAddress.Script,
+		To:              toAddress.Script,
+		Amount:          amount,
+		Fee:             fee,
 		fromBlockNumber: fromBlockNumber,
+		UseIndexer:      useIndexer,
 	}, nil
 }
 
 func (p *Payment) GenerateTx(client rpc.Client) (*types.Transaction, error) {
+	if p.UseIndexer {
+		return generateTxWithIndexer(client, p)
+	} else {
+		return generateTx(client, p)
+	}
+}
+
+func generateTx(client rpc.Client, p *Payment) (*types.Transaction, error) {
 	collector := utils.NewCellCollector(client, p.From, utils.NewCapacityCellProcessor(p.Amount+p.Fee), p.fromBlockNumber)
 
 	result, err := collector.Collect()
@@ -81,8 +92,78 @@ func (p *Payment) GenerateTx(client rpc.Client) (*types.Transaction, error) {
 			tx.Outputs[0].Capacity = result.Capacity - p.Fee
 		}
 	}
+	var inputs []*types.CellInput
+	for _, cell := range result.Cells {
+		input := &types.CellInput{
+			Since: 0,
+			PreviousOutput: &types.OutPoint{
+				TxHash: cell.OutPoint.TxHash,
+				Index:  cell.OutPoint.Index,
+			},
+		}
+		inputs = append(inputs, input)
+	}
+	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, inputs)
+	if err != nil {
+		return nil, fmt.Errorf("add inputs to transaction error: %v", err)
+	}
 
-	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, result.Cells)
+	p.group = group
+	p.witnessArgs = witnessArgs
+	p.tx = tx
+	return tx, err
+}
+
+func generateTxWithIndexer(client rpc.Client, p *Payment) (*types.Transaction, error) {
+	searchKey := &indexer.SearchKey{
+		Script:     p.From,
+		ScriptType: indexer.ScriptTypeLock,
+	}
+	collector := utils.NewLiveCellCollector(client, searchKey, indexer.SearchOrderAsc, 1000, "", utils.NewCapacityLiveCellProcessor(p.Amount+p.Fee))
+	result, err := collector.Collect()
+	if err != nil {
+		return nil, fmt.Errorf("collect cell error: %v", err)
+	}
+
+	if result.Capacity < p.Amount+p.Fee {
+		return nil, fmt.Errorf("insufficient balance: %d", result.Capacity)
+	}
+
+	systemScripts, err := utils.NewSystemScripts(client)
+	if err != nil {
+		return nil, fmt.Errorf("load system script error: %v", err)
+	}
+
+	tx := transaction.NewSecp256k1SingleSigTx(systemScripts)
+	tx.Outputs = append(tx.Outputs, &types.CellOutput{
+		Capacity: p.Amount,
+		Lock:     p.To,
+	})
+	tx.OutputsData = [][]byte{{}}
+
+	if result.Capacity-p.Amount-p.Fee > 0 {
+		if result.Capacity-p.Amount-p.Fee >= 6100000000 {
+			tx.Outputs = append(tx.Outputs, &types.CellOutput{
+				Capacity: result.Capacity - p.Amount - p.Fee,
+				Lock:     p.From,
+			})
+			tx.OutputsData = [][]byte{{}, {}}
+		} else {
+			tx.Outputs[0].Capacity = result.Capacity - p.Fee
+		}
+	}
+	var inputs []*types.CellInput
+	for _, cell := range result.LiveCells {
+		input := &types.CellInput{
+			Since: 0,
+			PreviousOutput: &types.OutPoint{
+				TxHash: cell.OutPoint.TxHash,
+				Index:  cell.OutPoint.Index,
+			},
+		}
+		inputs = append(inputs, input)
+	}
+	group, witnessArgs, err := transaction.AddInputsForTransaction(tx, inputs)
 	if err != nil {
 		return nil, fmt.Errorf("add inputs to transaction error: %v", err)
 	}

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -13,16 +13,17 @@ import (
 )
 
 type Payment struct {
-	From        *types.Script
-	To          *types.Script
-	Amount      uint64
-	Fee         uint64
-	group       []int
-	witnessArgs *types.WitnessArgs
-	tx          *types.Transaction
+	From            *types.Script
+	To              *types.Script
+	Amount          uint64
+	Fee             uint64
+	group           []int
+	witnessArgs     *types.WitnessArgs
+	tx              *types.Transaction
+	fromBlockNumber uint64
 }
 
-func NewPayment(from, to string, amount, fee uint64) (*Payment, error) {
+func NewPayment(from, to string, amount, fee uint64, fromBlockNumber uint64) (*Payment, error) {
 	fromAddress, err := address.Parse(from)
 	if err != nil {
 		return nil, fmt.Errorf("parse from address %s error: %v", from, err)
@@ -41,11 +42,12 @@ func NewPayment(from, to string, amount, fee uint64) (*Payment, error) {
 		To:     toAddress.Script,
 		Amount: amount,
 		Fee:    fee,
+		fromBlockNumber: fromBlockNumber,
 	}, nil
 }
 
 func (p *Payment) GenerateTx(client rpc.Client) (*types.Transaction, error) {
-	collector := utils.NewCellCollector(client, p.From, utils.NewCapacityCellProcessor(p.Amount+p.Fee))
+	collector := utils.NewCellCollector(client, p.From, utils.NewCapacityCellProcessor(p.Amount+p.Fee), p.fromBlockNumber)
 
 	result, err := collector.Collect()
 	if err != nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/nervosnetwork/ckb-sdk-go/indexer"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -123,11 +124,25 @@ type Client interface {
 	// Batch Live cells
 	BatchLiveCells(ctx context.Context, batch []types.BatchLiveCellItem) error
 
+	///// ckb-indexer
+	//GetTip returns the latest height processed by indexer
+	GetTip(ctx context.Context) (*indexer.TipHeader, error)
+
+	//GetCellsCapacity returns the live cells capacity by the lock or type script.
+	GetCellsCapacity(ctx context.Context, searchKey *indexer.SearchKey) (*indexer.Capacity, error)
+
+	// GetCells returns the live cells collection by the lock or type script.
+	GetCells(ctx context.Context, searchKey *indexer.SearchKey, order indexer.SearchOrder, limit uint64, afterCursor string) (*indexer.LiveCells, error)
+
+	// GetTransactions returns the transactions collection by the lock or type script.
+	GetTransactions(ctx context.Context, searchKey *indexer.SearchKey, order indexer.SearchOrder, limit uint64, afterCursor string) (*indexer.Transactions, error)
+
 	// Close close client
 	Close()
 }
 type client struct {
-	c *rpc.Client
+	c       *rpc.Client
+	indexer indexer.Client
 }
 
 func Dial(url string) (Client, error) {
@@ -142,8 +157,28 @@ func DialContext(ctx context.Context, url string) (Client, error) {
 	return NewClient(c), nil
 }
 
+func DialWithIndexer(ckbUrl string, indexerUrl string) (Client, error) {
+	return DialWithIndexerContext(context.Background(), ckbUrl, indexerUrl)
+}
+
+func DialWithIndexerContext(ctx context.Context, ckbUrl string, indexerUrl string) (Client, error) {
+	ckb, err := rpc.DialContext(ctx, ckbUrl)
+	if err != nil {
+		return nil, err
+	}
+	index, err := indexer.DialContext(ctx, indexerUrl)
+	if err != nil {
+		return nil, err
+	}
+	return NewClientWithIndexer(ckb, index), nil
+}
+
 func NewClient(c *rpc.Client) Client {
-	return &client{c}
+	return &client{c, nil}
+}
+
+func NewClientWithIndexer(c *rpc.Client, indexer indexer.Client) Client {
+	return &client{c, indexer}
 }
 
 func (cli *client) Close() {
@@ -657,4 +692,32 @@ func (cli *client) BatchLiveCells(ctx context.Context, batch []types.BatchLiveCe
 		}
 	}
 	return nil
+}
+
+func (cli *client) GetTip(ctx context.Context) (*indexer.TipHeader, error) {
+	if cli.indexer == nil {
+		return nil, errors.New("please set indexer client")
+	}
+	return cli.indexer.GetTip(ctx)
+}
+
+func (cli *client) GetCellsCapacity(ctx context.Context, searchKey *indexer.SearchKey) (*indexer.Capacity, error) {
+	if cli.indexer == nil {
+		return nil, errors.New("please set indexer client")
+	}
+	return cli.indexer.GetCellsCapacity(ctx, searchKey)
+}
+
+func (cli *client) GetCells(ctx context.Context, searchKey *indexer.SearchKey, order indexer.SearchOrder, limit uint64, afterCursor string) (*indexer.LiveCells, error) {
+	if cli.indexer == nil {
+		return nil, errors.New("please set indexer client")
+	}
+	return cli.indexer.GetCells(ctx, searchKey, order, limit, afterCursor)
+}
+
+func (cli *client) GetTransactions(ctx context.Context, searchKey *indexer.SearchKey, order indexer.SearchOrder, limit uint64, afterCursor string) (*indexer.Transactions, error) {
+	if cli.indexer == nil {
+		return nil, errors.New("please set indexer client")
+	}
+	return cli.indexer.GetTransactions(ctx, searchKey, order, limit, afterCursor)
 }

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
-	mock_rpc "github.com/nervosnetwork/ckb-sdk-go/test/mock/rpc"
+	mockRpc "github.com/nervosnetwork/ckb-sdk-go/test/mock/rpc"
 )
 
 func TestGetTipBlockNumber(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mc := mock_rpc.NewMockClient(ctrl)
+	mc := mockRpc.NewMockClient(ctrl)
 
 	mc.
 		EXPECT().

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -359,14 +359,17 @@ func toCellWithStatus(status cellWithStatus) *types.CellWithStatus {
 		Cell: &types.CellInfo{
 			Output: &types.CellOutput{
 				Capacity: uint64(status.Cell.Output.Capacity),
-				Lock: &types.Script{
-					CodeHash: status.Cell.Output.Lock.CodeHash,
-					HashType: status.Cell.Output.Lock.HashType,
-					Args:     status.Cell.Output.Lock.Args,
-				},
 			},
 		},
 		Status: status.Status,
+	}
+
+	if status.Cell.Output.Lock != nil {
+		result.Cell.Output.Lock = &types.Script{
+			CodeHash: status.Cell.Output.Lock.CodeHash,
+			HashType: status.Cell.Output.Lock.HashType,
+			Args:     status.Cell.Output.Lock.Args,
+		}
 	}
 
 	if status.Cell.Data != nil {

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -64,21 +64,14 @@ func NewSecp256k1HybirdSigTx(scripts *utils.SystemScripts) *types.Transaction {
 	}
 }
 
-func AddInputsForTransaction(transaction *types.Transaction, cells []*types.Cell) ([]int, *types.WitnessArgs, error) {
-	if len(cells) == 0 {
+func AddInputsForTransaction(transaction *types.Transaction, inputs []*types.CellInput) ([]int, *types.WitnessArgs, error) {
+	if len(inputs) == 0 {
 		return nil, nil, errors.New("input cells empty")
 	}
-	group := make([]int, len(cells))
+	group := make([]int, len(inputs))
 	start := len(transaction.Witnesses)
-	for i := 0; i < len(cells); i++ {
-		cell := cells[i]
-		input := &types.CellInput{
-			Since: 0,
-			PreviousOutput: &types.OutPoint{
-				TxHash: cell.OutPoint.TxHash,
-				Index:  cell.OutPoint.Index,
-			},
-		}
+	for i := 0; i < len(inputs); i++ {
+		input := inputs[i]
 		transaction.Inputs = append(transaction.Inputs, input)
 		transaction.Witnesses = append(transaction.Witnesses, []byte{})
 		group[i] = start + i

--- a/types/batch.go
+++ b/types/batch.go
@@ -6,3 +6,10 @@ type BatchTransactionItem struct {
 	Result *TransactionWithStatus
 	Error  error
 }
+
+type BatchLiveCellItem struct {
+	OutPoint OutPoint
+	WithData bool
+	Result   *CellWithStatus
+	Error    error
+}

--- a/types/chain.go
+++ b/types/chain.go
@@ -60,6 +60,10 @@ type Script struct {
 	Args     []byte         `json:"args"`
 }
 
+func (script *Script) OccupiedCapacity() uint64 {
+	return uint64(len(script.Args)) + uint64(len(script.CodeHash.Bytes())) + 1
+}
+
 func (script *Script) Hash() (Hash, error) {
 	data, err := script.Serialize()
 	if err != nil {
@@ -93,6 +97,14 @@ type CellOutput struct {
 	Capacity uint64  `json:"capacity"`
 	Lock     *Script `json:"lock"`
 	Type     *Script `json:"type"`
+}
+
+func (o CellOutput) OccupiedCapacity(outputData []byte) uint64 {
+	occupiedCapacity := 8 + uint64(len(outputData)) + o.Lock.OccupiedCapacity()
+	if o.Type != nil {
+		occupiedCapacity += o.Type.OccupiedCapacity()
+	}
+	return occupiedCapacity
 }
 
 type Transaction struct {

--- a/types/chain_test.go
+++ b/types/chain_test.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"encoding/hex"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestScriptOccupiedCapacity(t *testing.T) {
+	args, _ := hex.DecodeString("3954acece65096bfa81258983ddb83915fc56bd8")
+	s := &Script{
+		CodeHash: HexToHash("0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"),
+		HashType: ScriptHashType("type"),
+		Args:     args,
+	}
+	expectedCapacity := uint64(len(s.CodeHash.Bytes())) + 1 + uint64(len(args))
+
+	assert.Equal(t, expectedCapacity, s.OccupiedCapacity())
+}
+
+func TestCellOutputOccupiedCapacityOnlyLock(t *testing.T) {
+	args, _ := hex.DecodeString("3954acece65096bfa81258983ddb83915fc56bd8")
+	s := &Script{
+		CodeHash: HexToHash("0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"),
+		HashType: ScriptHashType("type"),
+		Args:     args,
+	}
+	o := CellOutput{
+		Capacity: 100000000000,
+		Lock:     s,
+		Type:     nil,
+	}
+	expectedCapacity := 8 + s.OccupiedCapacity()
+
+	assert.Equal(t, expectedCapacity, o.OccupiedCapacity([]byte{}))
+}
+
+func TestCellOutputOccupiedCapacityWithLockTypeAndData(t *testing.T) {
+	args, _ := hex.DecodeString("3954acece65096bfa81258983ddb83915fc56bd8")
+	s := &Script{
+		CodeHash: HexToHash("0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"),
+		HashType: ScriptHashType("type"),
+		Args:     args,
+	}
+	tArgs, _ := hex.DecodeString("32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947")
+	ts := &Script{
+		CodeHash: HexToHash("0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"),
+		HashType: ScriptHashType("type"),
+		Args:     tArgs,
+	}
+	o := CellOutput{
+		Capacity: 100000000000,
+		Lock:     s,
+		Type:     ts,
+	}
+	data, _ := hex.DecodeString("a0860100000000000000000000000000")
+	expectedCapacity := 8 + s.OccupiedCapacity() + ts.OccupiedCapacity() + uint64(len(data))
+
+	assert.Equal(t, expectedCapacity, o.OccupiedCapacity(data))
+}

--- a/utils/cell_collector.go
+++ b/utils/cell_collector.go
@@ -37,12 +37,13 @@ func (p *CapacityCellProcessor) Process(cell *types.Cell, result *CollectResult)
 }
 
 type CellCollector struct {
-	Client     rpc.Client
-	LockScript *types.Script
-	TypeScript *types.Script
-	Processor  CellProcessor
-	UseIndex   bool
-	EmptyData  bool
+	Client          rpc.Client
+	LockScript      *types.Script
+	TypeScript      *types.Script
+	Processor       CellProcessor
+	UseIndex        bool
+	EmptyData       bool
+	FromBlockNumber uint64
 }
 
 func NewCellCollector(client rpc.Client, lockScript *types.Script, processor CellProcessor) *CellCollector {
@@ -69,7 +70,7 @@ func (c *CellCollector) collectFromBlocks(lockHash types.Hash) (*CollectResult, 
 	}
 	var result CollectResult
 	result.Options = make(map[string]interface{})
-	var start uint64
+	start := c.FromBlockNumber
 	var stop bool
 	for {
 		end := start + 100

--- a/utils/live_cell_collector.go
+++ b/utils/live_cell_collector.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"github.com/nervosnetwork/ckb-sdk-go/indexer"
+	"github.com/nervosnetwork/ckb-sdk-go/rpc"
+)
+
+type LiveCellCollectResult struct {
+	LiveCells []*indexer.LiveCell
+	Capacity  uint64
+	Options   map[string]interface{}
+}
+
+type LiveCellProcessor interface {
+	Process(*indexer.LiveCell, *LiveCellCollectResult) (bool, error)
+}
+
+type CapacityLiveCellProcessor struct {
+	Max uint64
+}
+
+func NewCapacityLiveCellProcessor(capacity uint64) *CapacityLiveCellProcessor {
+	return &CapacityLiveCellProcessor{
+		Max: capacity,
+	}
+}
+
+func (p *CapacityLiveCellProcessor) Process(liveCell *indexer.LiveCell, result *LiveCellCollectResult) (bool, error) {
+	result.Capacity = result.Capacity + liveCell.Output.Capacity
+	result.LiveCells = append(result.LiveCells, liveCell)
+	if p.Max > 0 && result.Capacity >= p.Max {
+		return true, nil
+	}
+	return false, nil
+}
+
+type LiveCellCollector struct {
+	Client      rpc.Client
+	SearchKey   *indexer.SearchKey
+	SearchOrder indexer.SearchOrder
+	Limit       uint64
+	AfterCursor string
+	Processor   LiveCellProcessor
+}
+
+func (c *LiveCellCollector) collectFromCkbIndexer() (*LiveCellCollectResult, error) {
+	cursor := c.AfterCursor
+	var result LiveCellCollectResult
+	var stop bool
+	for {
+		liveCells, err := c.Client.GetCells(context.Background(), c.SearchKey, c.SearchOrder, c.Limit, cursor)
+		if err != nil {
+			return nil, err
+		}
+		for _, cell := range liveCells.Objects {
+			if cell.Output.Type == nil && len(cell.OutputData) == 0 {
+				s, err := c.Processor.Process(cell, &result)
+				if err != nil {
+					return nil, err
+				}
+				if s {
+					stop = s
+					break
+				}
+			}
+		}
+		if stop || len(liveCells.Objects) < int(c.Limit) || liveCells.LastCursor == "" {
+			break
+		}
+		cursor = liveCells.LastCursor
+	}
+	return &result, nil
+}
+
+func NewLiveCellCollector(client rpc.Client, searchKey *indexer.SearchKey, searchOrder indexer.SearchOrder, limit uint64, afterCursor string, processor LiveCellProcessor) *LiveCellCollector {
+	return &LiveCellCollector{
+		Client:      client,
+		SearchKey:   searchKey,
+		SearchOrder: searchOrder,
+		Limit:       limit,
+		AfterCursor: afterCursor,
+		Processor:   processor,
+	}
+}
+
+func (c *LiveCellCollector) Collect() (*LiveCellCollectResult, error) {
+	if c.SearchKey == nil {
+		return nil, errors.New("missing SearchKey error")
+	}
+	if c.SearchOrder != indexer.SearchOrderAsc && c.SearchOrder != indexer.SearchOrderDesc {
+		return nil, errors.New("missing SearchOrder error")
+	}
+	return c.collectFromCkbIndexer()
+}

--- a/utils/system.go
+++ b/utils/system.go
@@ -7,6 +7,11 @@ import (
 	"github.com/nervosnetwork/ckb-sdk-go/types"
 )
 
+const (
+	AnyoneCanPayCodeHashOnLina   = "0xd369597ff47f29fbc0d47d2e3775370d1250b85140c670e4718af712983a2354"
+	AnyoneCanPayCodeHashOnAggron = "0x3419a1c09eb2567f6552ee7a8ecffd64155cffe0f1796e6e61ec088d740c1356"
+)
+
 type SystemScriptCell struct {
 	CellHash types.Hash
 	OutPoint *types.OutPoint

--- a/utils/util.go
+++ b/utils/util.go
@@ -6,10 +6,12 @@ import (
 )
 
 func ParseSudtAmount(outputData []byte) (*big.Int, error) {
-	if len(outputData) < 16 {
+	tmpData := make([]byte, len(outputData))
+	copy(tmpData, outputData)
+	if len(tmpData) < 16 {
 		return nil, errors.New("invalid sUDT amount")
 	}
-	b := outputData[0:16]
+	b := tmpData[0:16]
 	b = reverse(b)
 
 	return big.NewInt(0).SetBytes(b), nil

--- a/utils/util.go
+++ b/utils/util.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"errors"
+	"math/big"
+)
+
+func ParseSudtAmount(outputData []byte) (*big.Int, error) {
+	if len(outputData) < 16 {
+		return nil, errors.New("invalid sUDT amount")
+	}
+	b := outputData[0:16]
+	b = reverse(b)
+
+	return big.NewInt(0).SetBytes(b), nil
+}
+
+func GenerateSudtAmount(amount *big.Int) []byte {
+	b := amount.Bytes()
+	b = reverse(b)
+	if len(b) < 16 {
+		for i := len(b); i < 16; i++ {
+			b = append(b, 0)
+		}
+	}
+
+	return b
+}
+
+func reverse(b []byte) []byte {
+	for i := 0; i < len(b)/2; i++ {
+		b[i], b[len(b)-i-1] = b[len(b)-i-1], b[i]
+	}
+	return b
+}

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"testing"
+)
+
+func TestGenerateSudtAmount(t *testing.T) {
+	amount := big.NewInt(10000000)
+	data := GenerateSudtAmount(amount)
+	expectedData := []byte{0x80, 0x96, 0x98, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	assert.Equal(t, expectedData, data)
+}
+
+func TestParseSudtAmountReturnError(t *testing.T) {
+	data := []byte{0x80, 0x96}
+	_, err := ParseSudtAmount(data)
+
+	assert.Error(t, err)
+}
+
+func TestParseSudtAmountWith16BytesData(t *testing.T) {
+	data := []byte{0x80, 0xC3, 0xC9, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	amount, err := ParseSudtAmount(data)
+	assert.NoError(t, err)
+	assert.True(t, big.NewInt(30000000).Cmp(amount) == 0)
+}


### PR DESCRIPTION
# [v0.2.0](https://github.com/nervosnetwork/ckb-bitpie-sdk/compare/v0.1.0...v0.2.0) (2020-11-25)


### Bug Fixes

* [#5](https://github.com/nervosnetwork/ckb-sdk-go/pull/5): fix nil pointer dereference on toCellWithStatus function
* [#7](https://github.com/nervosnetwork/ckb-sdk-go/pull/7): fix tx fee calculation bug


### Features

* [#6](https://github.com/nervosnetwork/ckb-sdk-go/pull/6): support ckb indexer
* [#8](https://github.com/nervosnetwork/ckb-sdk-go/pull/8): support ckb indexer on payment
* [#9](https://github.com/nervosnetwork/ckb-sdk-go/pull/9): add OccupiedCapacity function
* [#10](https://github.com/nervosnetwork/ckb-sdk-go/pull/10): support generate and parse short acp address
