### PR TITLE
feat: support RPC: `get_fee_rate_statics`

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -73,6 +73,9 @@ type Client interface {
 	// Note that the given block is included in the median time. The included block number range is [MAX(block - 36, 0), block].
 	GetBlockMedianTime(ctx context.Context, blockHash types.Hash) (uint64, error)
 
+	// GetFeeRateStatics Returns the fee_rate statistics of confirmed blocks on the chain
+	GetFeeRateStatics(ctx context.Context, target uint64) (*types.FeeRateStatics, error)
+
 	////// Experiment
 	// DryRunTransaction dry run transaction and return the execution cycles.
 	// This method will not check the transaction validity,
@@ -154,6 +157,8 @@ type Client interface {
 
 	//GetCellsCapacity returns the live cells capacity by the lock or type script.
 	GetCellsCapacity(ctx context.Context, searchKey *indexer.SearchKey) (*indexer.Capacity, error)
+
+
 
 	// Close close client
 	Close()
@@ -381,6 +386,15 @@ func (cli *client) GetBlockMedianTime(ctx context.Context, blockHash types.Hash)
 		return uint64(result), nil
 	}
 	return uint64(result), nil
+}
+
+func (cli *client) GetFeeRateStatics(ctx context.Context, target uint64) (*types.FeeRateStatics, error) {
+	var result types.FeeRateStatics
+	err := cli.c.CallContext(ctx, &result, "get_fee_rate_statics", hexutil.Uint64(target))
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 func (cli *client) LocalNodeInfo(ctx context.Context) (*types.LocalNode, error) {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -390,3 +390,9 @@ func TestGetTransactionsGrouped(t *testing.T) {
 	assert.NotEmpty(t, resp.Objects[0].Cells[0].IoType)
 	assert.NotEmpty(t, resp.Objects[0].Cells[0].IoIndex)
 }
+
+func TestClient_GetFeeRateStatics(t *testing.T) {
+	statics, err := testClient.GetFeeRateStatics(context.Background(), 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, statics)
+}

--- a/types/chain.go
+++ b/types/chain.go
@@ -303,3 +303,8 @@ type Proof struct {
 type EstimateCycles struct {
 	Cycles uint64 `json:"cycles"`
 }
+
+type FeeRateStatics struct {
+	Mean   float64 `json:"mean"`
+	Median float64 `json:"median"`
+}

--- a/types/chain.go
+++ b/types/chain.go
@@ -305,6 +305,6 @@ type EstimateCycles struct {
 }
 
 type FeeRateStatics struct {
-	Mean   float64 `json:"mean"`
-	Median float64 `json:"median"`
+	Mean   uint64 `json:"mean"`
+	Median uint64 `json:"median"`
 }

--- a/types/json.go
+++ b/types/json.go
@@ -729,3 +729,30 @@ func (r *EstimateCycles) UnmarshalJSON(input []byte) error {
 	}
 	return nil
 }
+
+type JsonFeeRateStatics struct {
+	Mean   hexutil.Uint64 `json:"mean"`
+	Median hexutil.Uint64 `json:"median"`
+}
+
+func (r *FeeRateStatics) UnmarshalJSON(input []byte) error {
+	var result JsonFeeRateStatics
+	if err := json.Unmarshal(input, &result); err != nil {
+		return err
+	}
+
+	*r = FeeRateStatics{
+		Mean:   uint64(result.Mean),
+		Median: uint64(result.Median),
+	}
+	return nil
+}
+
+func (r *FeeRateStatics) MarshalJSON() ([]byte, error) {
+	jsonObj := &JsonFeeRateStatics{
+		Mean:   hexutil.Uint64(r.Mean),
+		Median: hexutil.Uint64(r.Median),
+	}
+
+	return json.Marshal(jsonObj)
+}


### PR DESCRIPTION
- Adding RPC support for `get_fee_rate_statics`
- Adding a new type `FeeRateStatics` , [ref](https://github.com/nervosnetwork/ckb/tree/develop/rpc#type-feeratestatics)