### PR TITLE
Supporting nil target in GetFeeRateStatics

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -406,7 +406,10 @@ func TestGetTransactionsGrouped(t *testing.T) {
 }
 
 func TestClient_GetFeeRateStatics(t *testing.T) {
-	statics, err := testClient.GetFeeRateStatics(context.Background(), 1)
+	statics, err := testClient.GetFeeRateStatics(context.Background(), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, statics)
+	statics2, err := testClient.GetFeeRateStatics(context.Background(), 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, statics2)
 }


### PR DESCRIPTION
change 
```go
GetFeeRateStatics(ctx context.Context, target uint64) (*types.FeeRateStatics, error)
``` 
into
```go
GetFeeRateStatics(ctx context.Context, target interface{}) (*types.FeeRateStatics, error)
```
Which allows a nil `target` parameter

close #185 