### PR TITLE
Fix: last elem in offchancell skipped

### DIFF
--- a/collector/offchain_input_iterator.go
+++ b/collector/offchain_input_iterator.go
@@ -59,13 +59,13 @@ func (r *OffChainInputIterator) Next() *types.TransactionInput {
 func (r *OffChainInputIterator) consumeNextOffChainCell() *types.TransactionInput {
 	var next *list.Element
 	for it := r.Collector.offChainLiveCells.Front(); it != nil; it = next {
-		next = it.Next()
-		if next != nil {
+		if it != nil {
 			if r.isTransactionInputForSearchKey(next.Value.(TransactionInputWithBlockNumber), r.Iterator.SearchKey) {
 				r.Collector.offChainLiveCells.Remove(it)
 				var result = next.Value.(TransactionInputWithBlockNumber)
 				return &result.TransactionInput
 			}
+			next = it.Next()
 		}
 	}
 	return nil


### PR DESCRIPTION
Refers to #191 
The iterator result get from `list.List.Front()` is not a "Before head iterator".
So the last elem in the list will always skipped.

close #191 