### PR TITLE
fix: consume off chain cell bug

### DIFF
--- a/collector/offchain_input_iterator.go
+++ b/collector/offchain_input_iterator.go
@@ -60,9 +60,9 @@ func (r *OffChainInputIterator) consumeNextOffChainCell() *types.TransactionInpu
 	var next *list.Element
 	for it := r.Collector.offChainLiveCells.Front(); it != nil; it = next {
 		if it != nil {
-			if r.isTransactionInputForSearchKey(next.Value.(TransactionInputWithBlockNumber), r.Iterator.SearchKey) {
+			if r.isTransactionInputForSearchKey(it.Value.(TransactionInputWithBlockNumber), r.Iterator.SearchKey) {
 				r.Collector.offChainLiveCells.Remove(it)
-				var result = next.Value.(TransactionInputWithBlockNumber)
+				var result = it.Value.(TransactionInputWithBlockNumber)
 				return &result.TransactionInput
 			}
 			next = it.Next()

--- a/collector/offchain_input_iterator.go
+++ b/collector/offchain_input_iterator.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"container/list"
+	"fmt"
 	"github.com/nervosnetwork/ckb-sdk-go/v2/indexer"
 	"github.com/nervosnetwork/ckb-sdk-go/v2/rpc"
 	"github.com/nervosnetwork/ckb-sdk-go/v2/types"
@@ -43,7 +44,7 @@ func (r *OffChainInputIterator) HasNext() bool {
 
 func (r *OffChainInputIterator) Next() *types.TransactionInput {
 	r.update()
-	r.current = r.Iterator.cells[r.Iterator.index]
+	fmt.Printf("current: %+v\n", r.current)
 	if r.current != nil {
 		if !r.isCurrentFromOffChain {
 			r.Iterator.index++
@@ -59,8 +60,10 @@ func (r *OffChainInputIterator) Next() *types.TransactionInput {
 func (r *OffChainInputIterator) consumeNextOffChainCell() *types.TransactionInput {
 	var next *list.Element
 	for it := r.Collector.offChainLiveCells.Front(); it != nil; it = next {
+		fmt.Printf("it: %+v\n", it)
 		if it != nil {
 			if r.isTransactionInputForSearchKey(it.Value.(TransactionInputWithBlockNumber), r.Iterator.SearchKey) {
+				fmt.Println("pass")
 				r.Collector.offChainLiveCells.Remove(it)
 				var result = it.Value.(TransactionInputWithBlockNumber)
 				return &result.TransactionInput
@@ -79,6 +82,7 @@ func (r *OffChainInputIterator) update() bool {
 
 	if r.ConsumeOffChainCellsFirstly {
 		r.current = r.consumeNextOffChainCell()
+		fmt.Printf("current: %+v\n", r.current)
 		if r.current != nil {
 			r.isCurrentFromOffChain = true
 			return true


### PR DESCRIPTION
In general, the current version cannot use offchain cell mainly because of the following three problems:

* never use offchain cell, https://github.com/nervosnetwork/ckb-sdk-go/pull/196/files#diff-e07325bb986f42ea3feed3f589464564fb219542b7e6af8192633754f7bb6c80L46 because `current` will be overwritten by live cell.
* nil pointer error, https://github.com/nervosnetwork/ckb-sdk-go/pull/196/files#diff-e07325bb986f42ea3feed3f589464564fb219542b7e6af8192633754f7bb6c80L63 because the initial value of `next` is nil.
* script is a variable of pointer type and cannot be compared with `!=` https://github.com/nervosnetwork/ckb-sdk-go/pull/196/files#diff-e07325bb986f42ea3feed3f589464564fb219542b7e6af8192633754f7bb6c80L110 