### PR TITLE
feat: adding support for get block rpcs `with_cycles` and `verbosity0` version

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -39,25 +39,25 @@ type Client interface {
 	GetBlock(ctx context.Context, hash types.Hash) (*types.Block, error)
 
 	// GetBlockVerbosity0 returns the information about a block by hash, but with verbosity specified to 0.
-	GetBlockVerbosity0(ctx context.Context, hash types.Hash) (*types.Block, error)
+	GetPackedBlock(ctx context.Context, hash types.Hash) (*types.Block, error)
 
 	// GetBlockWithCycles returns the information about a block by hash(with cycles info).
 	GetBlockWithCycles(ctx context.Context, hash types.Hash) (*types.BlockWithCycles, error)
 
 	// GetBlockWithCyclesVerbosity0 returns the information about a block by hash(with cycles info), but with verbosity specified to 0.
-	GetBlockWithCyclesVerbosity0(ctx context.Context, hash types.Hash) (*types.BlockWithCycles, error)
+	GetPackedBlockWithCycles(ctx context.Context, hash types.Hash) (*types.BlockWithCycles, error)
 
 	// GetHeader returns the information about a block header by hash.
 	GetHeader(ctx context.Context, hash types.Hash) (*types.Header, error)
 
 	// GetHeaderVerbosity0 returns the information about a block header by hash, but with verbosity specified to 0.
-	GetHeaderVerbosity0(ctx context.Context, hash types.Hash) (*types.Header, error)
+	GetPackedHeader(ctx context.Context, hash types.Hash) (*types.Header, error)
 
 	// GetHeaderByNumber returns the information about a block header by block number.
 	GetHeaderByNumber(ctx context.Context, number uint64) (*types.Header, error)
 
 	// GetHeaderByNumberVerbosity0 returns the information about a block header by block number.
-	GetHeaderByNumberVerbosity0(ctx context.Context, number uint64) (*types.Header, error)
+	GetPackedHeaderByNumber(ctx context.Context, number uint64) (*types.Header, error)
 	// GetLiveCell returns the information about a cell by out_point if it is live.
 	// If second with_data argument set to true, will return cell data and data_hash if it is live.
 	GetLiveCell(ctx context.Context, outPoint *types.OutPoint, withData bool) (*types.CellWithStatus, error)
@@ -275,13 +275,13 @@ func (cli *client) GetBlock(ctx context.Context, hash types.Hash) (*types.Block,
 	return &result, nil
 }
 
-func (cli *client) GetBlockVerbosity0(ctx context.Context, hash types.Hash) (*types.Block, error) {
-	var jsonResult types.BlockVerbosity0
+func (cli *client) GetPackedBlock(ctx context.Context, hash types.Hash) (*types.Block, error) {
+	var jsonResult types.PackedBlock
 	err := cli.c.CallContext(ctx, &jsonResult, "get_block", hash, hexutil.Uint64(0))
 	if err != nil {
 		return nil, err
 	}
-	if (reflect.DeepEqual(jsonResult, types.BlockVerbosity0{})) {
+	if (reflect.DeepEqual(jsonResult, types.PackedBlock{})) {
 		return nil, NotFound
 	}
 
@@ -308,13 +308,13 @@ func (cli *client) GetBlockWithCycles(ctx context.Context, hash types.Hash) (*ty
 	return &result, nil
 }
 
-func (cli *client) GetBlockWithCyclesVerbosity0(ctx context.Context, hash types.Hash) (*types.BlockWithCycles, error) {
-	var jsonResult types.BlockVerbosity0WithCycles
+func (cli *client) GetPackedBlockWithCycles(ctx context.Context, hash types.Hash) (*types.BlockWithCycles, error) {
+	var jsonResult types.PackedBlockWithCycles
 	err := cli.c.CallContext(ctx, &jsonResult, "get_block", hash, hexutil.Uint64(0), true)
 	if err != nil {
 		return nil, err
 	}
-	if (reflect.DeepEqual(jsonResult, types.BlockVerbosity0{})) {
+	if (reflect.DeepEqual(jsonResult, types.PackedBlock{})) {
 		return nil, NotFound
 	}
 	blockBytes, err := hexutil.Decode(jsonResult.Block)
@@ -341,7 +341,7 @@ func (cli *client) GetHeader(ctx context.Context, hash types.Hash) (*types.Heade
 	return &result, nil
 }
 
-func (cli *client) GetHeaderVerbosity0(ctx context.Context, hash types.Hash) (*types.Header, error) {
+func (cli *client) GetPackedHeader(ctx context.Context, hash types.Hash) (*types.Header, error) {
 	var headerHash string
 	err := cli.c.CallContext(ctx, &headerHash, "get_header", hash, hexutil.Uint64(0))
 	if err != nil {
@@ -367,7 +367,7 @@ func (cli *client) GetHeaderByNumber(ctx context.Context, number uint64) (*types
 	return &result, nil
 }
 
-func (cli *client) GetHeaderByNumberVerbosity0(ctx context.Context, number uint64) (*types.Header, error) {
+func (cli *client) GetPackedHeaderByNumber(ctx context.Context, number uint64) (*types.Header, error) {
 	var headerHash string
 	err := cli.c.CallContext(ctx, &headerHash, "get_header_by_number", hexutil.Uint64(number), hexutil.Uint64(0))
 	if err != nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -37,6 +37,9 @@ type Client interface {
 	// GetBlock returns the information about a block by hash.
 	GetBlock(ctx context.Context, hash types.Hash) (*types.Block, error)
 
+	// GetBlockWithCycles returns the information about a block by hash(with cycles info).
+	GetBlockWithCycles(ctx context.Context, hash types.Hash) (*types.BlockWithCycles, error)
+
 	// GetHeader returns the information about a block header by hash.
 	GetHeader(ctx context.Context, hash types.Hash) (*types.Header, error)
 
@@ -61,6 +64,9 @@ type Client interface {
 
 	// GetBlockByNumber get block by number
 	GetBlockByNumber(ctx context.Context, number uint64) (*types.Block, error)
+
+	// GetBlockByNumber get block by number
+	GetBlockByNumberWithCycles(ctx context.Context, number uint64) (*types.BlockWithCycles, error)
 
 	// GetForkBlock The RPC returns a fork block or null. When the RPC returns a block, the block hash must equal to the parameter block_hash.
 	GetForkBlock(ctx context.Context, blockHash types.Hash) (*types.Block, error)
@@ -257,6 +263,30 @@ func (cli *client) GetBlock(ctx context.Context, hash types.Hash) (*types.Block,
 	return &result, nil
 }
 
+func (cli *client) GetBlockWithCycles(ctx context.Context, hash types.Hash) (*types.BlockWithCycles, error) {
+	var result types.BlockWithCycles
+	err := cli.c.CallContext(ctx, &result, "get_block", hash, nil, true)
+	if err != nil {
+		return nil, err
+	}
+	if (reflect.DeepEqual(result, types.BlockWithCycles{})) {
+		return nil, NotFound
+	}
+	return &result, nil
+}
+
+func (cli *client) GetBlockVerbosity0(ctx context.Context, hash types.Hash) (*types.BlockVerbosity0, error) {
+	var result types.BlockVerbosity0
+	err := cli.c.CallContext(ctx, &result, "get_block", hash, hexutil.Uint64(0))
+	if err != nil {
+		return nil, err
+	}
+	if (reflect.DeepEqual(result, types.BlockVerbosity0{})) {
+		return nil, NotFound
+	}
+	return &result, nil
+}
+
 func (cli *client) GetHeader(ctx context.Context, hash types.Hash) (*types.Header, error) {
 	var result types.Header
 	err := cli.c.CallContext(ctx, &result, "get_header", hash)
@@ -316,6 +346,18 @@ func (cli *client) GetTransaction(ctx context.Context, hash types.Hash) (*types.
 func (cli *client) GetBlockByNumber(ctx context.Context, number uint64) (*types.Block, error) {
 	var result types.Block
 	err := cli.c.CallContext(ctx, &result, "get_block_by_number", hexutil.Uint64(number))
+	if err != nil {
+		return nil, err
+	}
+	if (reflect.DeepEqual(result, types.Block{})) {
+		return nil, NotFound
+	}
+	return &result, nil
+}
+
+func (cli *client) GetBlockByNumberWithCycles(ctx context.Context, number uint64) (*types.BlockWithCycles, error) {
+	var result types.BlockWithCycles
+	err := cli.c.CallContext(ctx, &result, "get_block_by_number", hexutil.Uint64(number), nil, true)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -29,6 +29,14 @@ func TestClient_GetBlockByNumber(t *testing.T) {
 	assert.Equal(t, 1, len(block.Transactions))
 }
 
+func TestClient_GetBlockByNumberWithCycles(t *testing.T) {
+	block, err := testClient.GetBlockByNumberWithCycles(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, len(block.Block.Transactions))
+}
+
 func TestClient_GetBlockHash(t *testing.T) {
 	blockHash, err := testClient.GetBlockHash(ctx, 1)
 	if err != nil {
@@ -56,6 +64,16 @@ func TestClient_GetBlock(t *testing.T) {
 	}
 	assert.Equal(t, 1, len(block.Transactions))
 	assert.NotNil(t, block.Header)
+}
+
+func TestClient_GetBlockWithCycles(t *testing.T) {
+	block, err := testClient.GetBlockWithCycles(ctx,
+		types.HexToHash("0xd5ac7cf8c34a975bf258a34f1c2507638487ab71aa4d10a9ec73704aa3abf9cd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, len(block.Block.Transactions))
+	assert.NotNil(t, block.Block.Header)
 }
 
 func TestClient_GetTransaction(t *testing.T) {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -67,7 +67,7 @@ func TestClient_GetBlock(t *testing.T) {
 }
 
 func TestClient_GetBlockVerbosity0(t *testing.T) {
-	block, err := testClient.GetBlockVerbosity0(ctx,
+	block, err := testClient.GetPackedBlock(ctx,
 		types.HexToHash("0xd5ac7cf8c34a975bf258a34f1c2507638487ab71aa4d10a9ec73704aa3abf9cd"))
 	if err != nil {
 		t.Fatal(err)
@@ -168,7 +168,7 @@ func TestClient_GetHeader(t *testing.T) {
 }
 
 func TestClient_GetHeaderVerbosity0(t *testing.T) {
-	header, err := testClient.GetHeaderVerbosity0(ctx,
+	header, err := testClient.GetPackedHeader(ctx,
 		types.HexToHash("0xd5ac7cf8c34a975bf258a34f1c2507638487ab71aa4d10a9ec73704aa3abf9cd"))
 	if err != nil {
 		t.Fatal(err)
@@ -187,7 +187,7 @@ func TestClient_GetHeaderByNumber(t *testing.T) {
 }
 
 func TestClient_GetHeaderByNumberVerbosity0(t *testing.T) {
-	header, err := testClient.GetHeaderByNumberVerbosity0(ctx, 1)
+	header, err := testClient.GetPackedHeaderByNumber(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -66,6 +66,26 @@ func TestClient_GetBlock(t *testing.T) {
 	assert.NotNil(t, block.Header)
 }
 
+func TestClient_GetBlockVerbosity0(t *testing.T) {
+	block, err := testClient.GetBlockVerbosity0(ctx,
+		types.HexToHash("0xd5ac7cf8c34a975bf258a34f1c2507638487ab71aa4d10a9ec73704aa3abf9cd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, len(block.Transactions))
+	assert.NotNil(t, block.Header)
+
+	// verify equivalent
+	block2, err := testClient.GetBlock(ctx,
+		types.HexToHash("0xd5ac7cf8c34a975bf258a34f1c2507638487ab71aa4d10a9ec73704aa3abf9cd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b1str := block.Header.Hash.String()
+	b2str := block2.Header.Hash.String()
+	assert.Equal(t, b1str, b2str)
+}
+
 func TestClient_GetBlockWithCycles(t *testing.T) {
 	block, err := testClient.GetBlockWithCycles(ctx,
 		types.HexToHash("0xd5ac7cf8c34a975bf258a34f1c2507638487ab71aa4d10a9ec73704aa3abf9cd"))
@@ -99,7 +119,7 @@ func TestClient_GetTransaction(t *testing.T) {
 	//assert.Nil(t, tx)
 	//assert.Equal(t, types.TransactionStatusRejected, status.Status)
 	//assert.NotNil(t, status.Reason)
-	//assert.Nil(t, status.BlockHash)
+	//assert.Nil(t, status.Block)
 }
 
 func TestClient_GetTipHeader(t *testing.T) {
@@ -147,8 +167,27 @@ func TestClient_GetHeader(t *testing.T) {
 	assert.Equal(t, uint64(1590137711584), header.Timestamp)
 }
 
+func TestClient_GetHeaderVerbosity0(t *testing.T) {
+	header, err := testClient.GetHeaderVerbosity0(ctx,
+		types.HexToHash("0xd5ac7cf8c34a975bf258a34f1c2507638487ab71aa4d10a9ec73704aa3abf9cd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, uint64(1), header.Number)
+	assert.Equal(t, uint64(1590137711584), header.Timestamp)
+}
+
 func TestClient_GetHeaderByNumber(t *testing.T) {
 	header, err := testClient.GetHeaderByNumber(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, uint64(1), header.Number)
+	assert.Equal(t, uint64(1590137711584), header.Timestamp)
+}
+
+func TestClient_GetHeaderByNumberVerbosity0(t *testing.T) {
+	header, err := testClient.GetHeaderByNumberVerbosity0(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/types/chain.go
+++ b/types/chain.go
@@ -179,6 +179,15 @@ type Block struct {
 	Uncles       []*UncleBlock  `json:"uncles"`
 }
 
+type BlockVerbosity0 struct {
+	BlockHash string `json:"block"`
+}
+
+type BlockWithCycles struct {
+	Block  *Block   `json:"block"`
+	Cycles []uint64 `json:"cycles"`
+}
+
 type TransactionInput struct {
 	OutPoint   *OutPoint   `json:"out_point"`
 	Output     *CellOutput `json:"output"`

--- a/types/chain.go
+++ b/types/chain.go
@@ -49,6 +49,10 @@ type Header struct {
 	Version          uint32   `json:"version"`
 }
 
+type HeaderVerbosity0 struct {
+	Header string `json:"header"`
+}
+
 type OutPoint struct {
 	TxHash Hash   `json:"tx_hash"`
 	Index  uint32 `json:"index"`
@@ -180,11 +184,16 @@ type Block struct {
 }
 
 type BlockVerbosity0 struct {
-	BlockHash string `json:"block"`
+	Block string `json:"block"`
 }
 
 type BlockWithCycles struct {
 	Block  *Block   `json:"block"`
+	Cycles []uint64 `json:"cycles"`
+}
+
+type BlockVerbosity0WithCycles struct {
+	Block  string   `json:"block"`
 	Cycles []uint64 `json:"cycles"`
 }
 

--- a/types/chain.go
+++ b/types/chain.go
@@ -49,7 +49,7 @@ type Header struct {
 	Version          uint32   `json:"version"`
 }
 
-type HeaderVerbosity0 struct {
+type PackedHeader struct {
 	Header string `json:"header"`
 }
 
@@ -183,7 +183,7 @@ type Block struct {
 	Uncles       []*UncleBlock  `json:"uncles"`
 }
 
-type BlockVerbosity0 struct {
+type PackedBlock struct {
 	Block string `json:"block"`
 }
 
@@ -192,7 +192,7 @@ type BlockWithCycles struct {
 	Cycles []uint64 `json:"cycles"`
 }
 
-type BlockVerbosity0WithCycles struct {
+type PackedBlockWithCycles struct {
 	Block  string   `json:"block"`
 	Cycles []uint64 `json:"cycles"`
 }

--- a/types/json.go
+++ b/types/json.go
@@ -793,7 +793,7 @@ func (r *TransactionWithStatus) UnmarshalJSON(input []byte) error {
 }
 
 func (r *BlockVerbosity0) UnmarshalJSON(input []byte) error {
-	if err := json.Unmarshal(input, &r.BlockHash); err != nil {
+	if err := json.Unmarshal(input, &r.Block); err != nil {
 		return err
 	}
 	return nil

--- a/types/json.go
+++ b/types/json.go
@@ -792,7 +792,7 @@ func (r *TransactionWithStatus) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (r *BlockVerbosity0) UnmarshalJSON(input []byte) error {
+func (r *PackedBlock) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(input, &r.Block); err != nil {
 		return err
 	}

--- a/types/json.go
+++ b/types/json.go
@@ -791,3 +791,10 @@ func (r *TransactionWithStatus) UnmarshalJSON(input []byte) error {
 	}
 	return nil
 }
+
+func (r *BlockVerbosity0) UnmarshalJSON(input []byte) error {
+	if err := json.Unmarshal(input, &r.BlockHash); err != nil {
+		return err
+	}
+	return nil
+}

--- a/types/molecule.go
+++ b/types/molecule.go
@@ -126,7 +126,7 @@ func UnpackCellDep(v *molecule.CellDep) *CellDep {
 	return c
 }
 
-func UnpackTrasaction(v *molecule.Transaction) *Transaction {
+func UnpackTransaction(v *molecule.Transaction) *Transaction {
 	tx := &Transaction{}
 
 	rawTx := v.Raw()
@@ -221,10 +221,10 @@ func UnpackBlock(v *molecule.Block) *Block {
 		}
 	}
 
-	// Trasactions
+	// Transactions
 	if !v.Transactions().IsEmpty() {
 		for i := uint(0); i < v.Transactions().ItemCount(); i++ {
-			block.Transactions = append(block.Transactions, UnpackTrasaction(v.Transactions().Get(i)))
+			block.Transactions = append(block.Transactions, UnpackTransaction(v.Transactions().Get(i)))
 		}
 	}
 


### PR DESCRIPTION
1. `with_cycles`:
Adds two new similar functions like `get_block` & `get_block_by_number`, which will get results with cycles
- `GetBlockWithCycles`
- `GetBlockByNumberWithCycles`
The input params are same form with the original fns

2. `verbosity0`:
Adds 4 new functions which specified the vebosity to be 0:
- `GetPackedBlock`
- `GetPackedBlockWithCycles`
- `GetPackedHeader`
- `GetPackedHeaderByNumber`