### PR TITLE
feat: support indexer search mode in SearchKey

### DIFF
--- a/collector/iterator.go
+++ b/collector/iterator.go
@@ -62,10 +62,11 @@ func newLiveCellIteratorFromAddress(getter LiveCellsGetter, addr string) (CellIt
 		return nil, err
 	}
 	searchKey := &indexer.SearchKey{
-		Script:     a.Script,
-		ScriptType: types.ScriptTypeLock,
-		Filter:     nil,
-		WithData:   true,
+		Script:           a.Script,
+		ScriptType:       types.ScriptTypeLock,
+		ScriptSearchMode: types.ScriptSearchModePrefix,
+		Filter:           nil,
+		WithData:         true,
 	}
 	return newLiveCellIterator(getter, searchKey), nil
 }

--- a/indexer/types.go
+++ b/indexer/types.go
@@ -16,10 +16,11 @@ const (
 )
 
 type SearchKey struct {
-	Script     *types.Script    `json:"script"`
-	ScriptType types.ScriptType `json:"script_type"`
-	Filter     *Filter          `json:"filter,omitempty"`
-	WithData   bool             `json:"with_data"`
+	Script           *types.Script          `json:"script"`
+	ScriptType       types.ScriptType       `json:"script_type"`
+	ScriptSearchMode types.ScriptSearchMode `json:"script_search_mode,omitempty"`
+	Filter           *Filter                `json:"filter,omitempty"`
+	WithData         bool                   `json:"with_data"`
 }
 
 type Filter struct {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -470,3 +470,50 @@ func TestClient_GetFeeRateStatics(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, statics2)
 }
+
+func TestClient_GetTransactions_PrefixMode(t *testing.T) {
+	s := &indexer.SearchKey{
+		Script: &types.Script{
+			CodeHash: types.HexToHash("0x58c5f491aba6d61678b7cf7edf4910b1f5e00ec0cde2f42e0abb4fd9aff25a63"),
+			HashType: types.HashTypeType,
+			Args:     ethcommon.FromHex("0xe53f35ccf63bb37a3bb0ac3b7f89808077a78eae"[0:4]),
+		},
+		ScriptType:       types.ScriptTypeLock,
+		ScriptSearchMode: types.ScriptSearchModePrefix,
+	}
+	resp, err := testClient.GetTransactions(context.Background(), s, indexer.SearchOrderAsc, 10, "")
+	assert.NoError(t, err)
+	assert.True(t, len(resp.Objects) >= 1)
+	assert.NotEqual(t, 0, resp.Objects[0].BlockNumber)
+	assert.NotEqual(t, "", resp.Objects[0].IoType)
+}
+
+func TestClient_GetTransactions_ExactMode(t *testing.T) {
+	s1 := &indexer.SearchKey{
+		Script: &types.Script{
+			CodeHash: types.HexToHash("0x58c5f491aba6d61678b7cf7edf4910b1f5e00ec0cde2f42e0abb4fd9aff25a63"),
+			HashType: types.HashTypeType,
+			Args:     ethcommon.FromHex("0xe53f35ccf63bb37a3bb0ac3b7f89808077a78eae"[0:4]),
+		},
+		ScriptType:       types.ScriptTypeLock,
+		ScriptSearchMode: types.ScriptSearchModeExact,
+	}
+	resp1, err := testClient.GetTransactions(context.Background(), s1, indexer.SearchOrderAsc, 10, "")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(resp1.Objects))
+
+	s2 := &indexer.SearchKey{
+		Script: &types.Script{
+			CodeHash: types.HexToHash("0x58c5f491aba6d61678b7cf7edf4910b1f5e00ec0cde2f42e0abb4fd9aff25a63"),
+			HashType: types.HashTypeType,
+			Args:     ethcommon.FromHex("0xe53f35ccf63bb37a3bb0ac3b7f89808077a78eae"),
+		},
+		ScriptType:       types.ScriptTypeLock,
+		ScriptSearchMode: types.ScriptSearchModeExact,
+	}
+	resp2, err := testClient.GetTransactions(context.Background(), s2, indexer.SearchOrderAsc, 10, "")
+	assert.NoError(t, err)
+	assert.True(t, len(resp2.Objects) >= 1)
+	assert.NotEqual(t, 0, resp2.Objects[0].BlockNumber)
+	assert.NotEqual(t, "", resp2.Objects[0].IoType)
+}

--- a/types/common.go
+++ b/types/common.go
@@ -10,6 +10,7 @@ import (
 type Network uint
 type WitnessType uint
 type ScriptType string
+type ScriptSearchMode string
 
 const (
 	HashLength = 32
@@ -23,6 +24,9 @@ const (
 
 	ScriptTypeLock ScriptType = "lock"
 	ScriptTypeType ScriptType = "type"
+
+	ScriptSearchModePrefix ScriptSearchMode = "prefix"
+	ScriptSearchModeExact  ScriptSearchMode = "exact"
 )
 
 var (


### PR DESCRIPTION
# What does this PR do
Adds support for `script_search_mode`  field in `SearchKey` fields introduced in  [feat: add exact search mode ckb-indexer#64](https://github.com/nervosnetwork/ckb-indexer/pull/64)

_Note:  To not influencing legacy codes, this field is set to `omitempty`, so it is safe to leave it not set if you just do not want the `Exact Search Mode`._