### PR TITLE
fix: `TransactionWithStatus` `Cycle` cant be `nil`

### DIFF
--- a/types/chain.go
+++ b/types/chain.go
@@ -236,7 +236,7 @@ type TxStatus struct {
 
 type TransactionWithStatus struct {
 	Transaction *Transaction `json:"transaction"`
-	Cycles      uint64       `json:"cycles"`
+	Cycles      *uint64      `json:"cycles"`
 	TxStatus    *TxStatus    `json:"tx_status"`
 }
 

--- a/types/json.go
+++ b/types/json.go
@@ -756,10 +756,38 @@ func (r *FeeRateStatics) MarshalJSON() ([]byte, error) {
 	return json.Marshal(jsonObj)
 }
 
+type jsonTransactionWithStatus struct {
+	Transaction *Transaction    `json:"transaction"`
+	Cycles      *hexutil.Uint64 `json:"cycles"`
+	TxStatus    *TxStatus       `json:"tx_status"`
+}
+
+func (r *TransactionWithStatus) MarshalJSON() ([]byte, error) {
+	jsonObj := &jsonTransactionWithStatus{
+		Transaction: r.Transaction,
+		TxStatus:    r.TxStatus,
+	}
+
+	if r.Cycles != nil {
+		jsonObj.Cycles = (*hexutil.Uint64)(r.Cycles)
+	}
+
+	return json.Marshal(jsonObj)
+}
+
 func (r *TransactionWithStatus) UnmarshalJSON(input []byte) error {
-	var result TransactionWithStatus
+	var result jsonTransactionWithStatus
 	if err := json.Unmarshal(input, &result); err != nil {
 		return err
+	}
+
+	*r = TransactionWithStatus{
+		Transaction: result.Transaction,
+		TxStatus:    result.TxStatus,
+	}
+
+	if result.Cycles != nil {
+		r.Cycles = (*uint64)(result.Cycles)
 	}
 	return nil
 }

--- a/types/json.go
+++ b/types/json.go
@@ -756,38 +756,10 @@ func (r *FeeRateStatics) MarshalJSON() ([]byte, error) {
 	return json.Marshal(jsonObj)
 }
 
-type jsonTransactionWithStatus struct {
-	Transaction *Transaction    `json:"transaction"`
-	Cycles      *hexutil.Uint64 `json:"cycles"`
-	TxStatus    *TxStatus       `json:"tx_status"`
-}
-
-func (r *TransactionWithStatus) MarshalJSON() ([]byte, error) {
-	jsonObj := &jsonTransactionWithStatus{
-		Transaction: r.Transaction,
-		TxStatus:    r.TxStatus,
-	}
-
-	if r.Cycles > 0 {
-		jsonObj.Cycles = (*hexutil.Uint64)(&r.Cycles)
-	}
-
-	return json.Marshal(jsonObj)
-}
-
 func (r *TransactionWithStatus) UnmarshalJSON(input []byte) error {
-	var result jsonTransactionWithStatus
+	var result TransactionWithStatus
 	if err := json.Unmarshal(input, &result); err != nil {
 		return err
-	}
-
-	*r = TransactionWithStatus{
-		Transaction: result.Transaction,
-		TxStatus:    result.TxStatus,
-	}
-
-	if result.Cycles != nil {
-		r.Cycles = uint64(*result.Cycles)
 	}
 	return nil
 }


### PR DESCRIPTION
# What does this PR do:

The original definition `TransactionWithStatus` contains `Cycle` field that can't be `nil`, which is ill-formed.
Change this into `*uint64` to fix this problem. When RPC's response is `null`, this field will be `nil`