### PR TITLE
feat: Add `time_added_to_pool`

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -103,10 +103,12 @@ func TestClient_GetTransaction(t *testing.T) {
 	assert.NoError(t, err)
 	tx := txView.Transaction
 	status := txView.TxStatus
+	timeAdded := txView.TimeAddedToPool
 	assert.Equal(t, 4, len(tx.CellDeps))
 	assert.Equal(t, 1, len(tx.Inputs))
 	assert.Equal(t, 3, len(tx.Outputs))
 	assert.Equal(t, uint64(30000000000), tx.Outputs[0].Capacity)
+	assert.NotEqual(t, nil, timeAdded)
 	assert.Equal(t, types.TransactionStatusCommitted, status.Status)
 	assert.NotNil(t, status.BlockHash)
 

--- a/types/chain.go
+++ b/types/chain.go
@@ -236,9 +236,10 @@ type TxStatus struct {
 }
 
 type TransactionWithStatus struct {
-	Transaction *Transaction `json:"transaction"`
-	Cycles      *uint64      `json:"cycles"`
-	TxStatus    *TxStatus    `json:"tx_status"`
+	Transaction     *Transaction `json:"transaction"`
+	Cycles          *uint64      `json:"cycles"`
+	TimeAddedToPool *uint64      `json:"time_added_to_pool"`
+	TxStatus        *TxStatus    `json:"tx_status"`
 }
 
 type BlockReward struct {

--- a/types/json.go
+++ b/types/json.go
@@ -757,9 +757,10 @@ func (r *FeeRateStatics) MarshalJSON() ([]byte, error) {
 }
 
 type jsonTransactionWithStatus struct {
-	Transaction *Transaction    `json:"transaction"`
-	Cycles      *hexutil.Uint64 `json:"cycles"`
-	TxStatus    *TxStatus       `json:"tx_status"`
+	Transaction     *Transaction    `json:"transaction"`
+	Cycles          *hexutil.Uint64 `json:"cycles"`
+	TimeAddedToPool *hexutil.Uint64 `json:"time_added_to_pool"`
+	TxStatus        *TxStatus       `json:"tx_status"`
 }
 
 func (r *TransactionWithStatus) MarshalJSON() ([]byte, error) {
@@ -770,6 +771,10 @@ func (r *TransactionWithStatus) MarshalJSON() ([]byte, error) {
 
 	if r.Cycles != nil {
 		jsonObj.Cycles = (*hexutil.Uint64)(r.Cycles)
+	}
+
+	if r.TimeAddedToPool != nil {
+		jsonObj.TimeAddedToPool = (*hexutil.Uint64)(r.TimeAddedToPool)
 	}
 
 	return json.Marshal(jsonObj)
@@ -789,6 +794,11 @@ func (r *TransactionWithStatus) UnmarshalJSON(input []byte) error {
 	if result.Cycles != nil {
 		r.Cycles = (*uint64)(result.Cycles)
 	}
+
+	if result.TimeAddedToPool != nil {
+		r.TimeAddedToPool = (*uint64)(result.TimeAddedToPool)
+	}
+
 	return nil
 }
 

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -156,6 +156,7 @@ func TestJsonTransactionWithStatus(t *testing.T) {
         ]
     },
     "cycles": "0x16e04e",
+    "time_added_to_pool": null,
     "tx_status": {
         "block_hash": "0xe1ed2d2282aad742a95abe51c21d50b1c19e194f21fbd1ed2516f82bd042579a",
         "status": "committed",
@@ -174,6 +175,7 @@ func TestRejectedJsonTransactionWithStatus(t *testing.T) {
 {
     "transaction": null,
     "cycles": null,
+    "time_added_to_pool": null,
     "tx_status": {
         "block_hash": "0xe1ed2d2282aad742a95abe51c21d50b1c19e194f21fbd1ed2516f82bd042579a",
         "status": "rejected",
@@ -194,6 +196,7 @@ func TestUnknownJsonTransactionWithStatus(t *testing.T) {
 {
     "transaction": null,
     "cycles": null,
+    "time_added_to_pool": null,
     "tx_status": {
         "block_hash": "0x7b00ed399a69eb6b4191ce45e8337835bf3ecadabb8d7281de50fa07fb2034f1",
         "status": "unknown",


### PR DESCRIPTION
# What does this PR do

Adds `TimeAddedToPool` to `TransactionWithStatus`

Check: https://github.com/nervosnetwork/ckb/tree/develop/rpc#type-transactionwithstatusresponse
