### PR TITLE
fix: Properly deserialize ScriptHashType within Script

### DIFF
--- a/types/molecule.go
+++ b/types/molecule.go
@@ -2,10 +2,12 @@ package types
 
 import (
 	"encoding/binary"
+	"fmt"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/nervosnetwork/ckb-sdk-go/v2/crypto/blake2b"
 	"github.com/nervosnetwork/ckb-sdk-go/v2/types/molecule"
-	"math/big"
 )
 
 func (r *WitnessArgs) Pack() *molecule.WitnessArgs {
@@ -78,11 +80,19 @@ func (t *Transaction) Pack() *molecule.Transaction {
 func UnpackScript(v *molecule.Script) *Script {
 	s := &Script{}
 	if !v.IsEmpty() {
-		s.HashType = ScriptHashType(v.HashType().AsSlice())
+		s.HashType = requireHashTypeByte(v.HashType())
 	}
 	s.Args = v.Args().RawData()
 	s.CodeHash = BytesToHash(v.CodeHash().RawData())
 	return s
+}
+
+func requireHashTypeByte(serializedHashType *molecule.Byte) ScriptHashType {
+	sht, err := DeserializeHashTypeByte(serializedHashType[0])
+	if err != nil {
+		panic(fmt.Sprintf("Deserializing HashType: %v", err))
+	}
+	return sht
 }
 
 func UnpackScriptOpt(v *molecule.ScriptOpt) *Script {

--- a/types/molecule_test.go
+++ b/types/molecule_test.go
@@ -1,0 +1,31 @@
+package types_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/nervosnetwork/ckb-sdk-go/v2/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScriptPacking(t *testing.T) {
+	rng := rand.New(rand.NewSource(1337))
+	for _, ty := range []types.ScriptHashType{types.HashTypeData, types.HashTypeType, types.HashTypeData1} {
+		script := newScript(rng, ty)
+		packed := types.UnpackScript(script.Pack())
+		assert.Equal(t, script, packed, "script packing/unpacking should satisfy the round-trip property")
+	}
+}
+
+func newScript(rng *rand.Rand, ht types.ScriptHashType) *types.Script {
+	hash := [32]byte{}
+	rng.Read(hash[:])
+	argsLen := rng.Intn(4096)
+	args := make([]byte, argsLen)
+	rng.Read(args)
+	return &types.Script{
+		CodeHash: hash,
+		HashType: ht,
+		Args:     args,
+	}
+}


### PR DESCRIPTION
Now using the `DeserializeHashTypeByte` function to unpack a serialized ScriptHashType. Before `UnpackScript` simply interpreted the encoded byte as a `ScriptHashType` which in turn resulted in unpacked Scripts where the `ScriptHashType` was set to `"\0x00"|"\0x01"|"\0x02"` instead of `"data"|"type"|"data1"`.

Also added a regression test.