### PR TITLE
feat: Adds support for ScriptHashType data2

### DIFF
--- a/types/chain.go
+++ b/types/chain.go
@@ -14,7 +14,7 @@ type TransactionStatus string
 const (
 	HashTypeData  ScriptHashType = "data"
 	HashTypeData1 ScriptHashType = "data1"
-  HashTypeData2 ScriptHashType = "data2"
+	HashTypeData2 ScriptHashType = "data2"
 	HashTypeType  ScriptHashType = "type"
 
 	DepTypeCode     DepType = "code"

--- a/types/chain.go
+++ b/types/chain.go
@@ -14,6 +14,7 @@ type TransactionStatus string
 const (
 	HashTypeData  ScriptHashType = "data"
 	HashTypeData1 ScriptHashType = "data1"
+  HashTypeData2 ScriptHashType = "data2"
 	HashTypeType  ScriptHashType = "type"
 
 	DepTypeCode     DepType = "code"

--- a/types/molecule.go
+++ b/types/molecule.go
@@ -377,6 +377,8 @@ func (t ScriptHashType) Pack() *molecule.Byte {
 		b = 0x01
 	case HashTypeData1:
 		b = 0x02
+  case HashTypeData2:
+    b = 0x04
 	default:
 		return nil
 	}

--- a/types/molecule.go
+++ b/types/molecule.go
@@ -377,8 +377,8 @@ func (t ScriptHashType) Pack() *molecule.Byte {
 		b = 0x01
 	case HashTypeData1:
 		b = 0x02
-  case HashTypeData2:
-    b = 0x04
+	case HashTypeData2:
+		b = 0x04
 	default:
 		return nil
 	}

--- a/types/serialize.go
+++ b/types/serialize.go
@@ -66,6 +66,8 @@ func SerializeHashTypeByte(hashType ScriptHashType) (byte, error) {
 		return 0x01, nil
 	case HashTypeData1:
 		return 0x02, nil
+  case HashTypeData2:
+    return 0x04, nil
 	default:
 		return 0, errors.New(string("unknown hash type " + hashType))
 	}
@@ -79,6 +81,8 @@ func DeserializeHashTypeByte(hashType byte) (ScriptHashType, error) {
 		return HashTypeType, nil
 	case 0x02:
 		return HashTypeData1, nil
+  case 0x04:
+    return HashTypeData2, nil
 	default:
 		return "", errors.New(fmt.Sprintf("invalid script hash_type: %x", hashType))
 	}

--- a/types/serialize.go
+++ b/types/serialize.go
@@ -66,8 +66,8 @@ func SerializeHashTypeByte(hashType ScriptHashType) (byte, error) {
 		return 0x01, nil
 	case HashTypeData1:
 		return 0x02, nil
-  case HashTypeData2:
-    return 0x04, nil
+	case HashTypeData2:
+		return 0x04, nil
 	default:
 		return 0, errors.New(string("unknown hash type " + hashType))
 	}
@@ -81,8 +81,8 @@ func DeserializeHashTypeByte(hashType byte) (ScriptHashType, error) {
 		return HashTypeType, nil
 	case 0x02:
 		return HashTypeData1, nil
-  case 0x04:
-    return HashTypeData2, nil
+	case 0x04:
+		return HashTypeData2, nil
 	default:
 		return "", errors.New(fmt.Sprintf("invalid script hash_type: %x", hashType))
 	}


### PR DESCRIPTION
# What does this PR do?
This PR adds support for ScriptHashType `data2` introduced by ckb hardfork 2023.
For more detail, check [0051-ckb2023](https://github.com/zhangsoledad/rfcs/blob/zhangsoledad/ckb2023-overview/rfcs/0051-ckb2023/0051-ckb2023.md)