### PR TITLE
fix: nil type script

### DIFF
--- a/collector/offchain_input_iterator.go
+++ b/collector/offchain_input_iterator.go
@@ -119,9 +119,10 @@ func (r *OffChainInputIterator) isTransactionInputForSearchKey(transactionInputW
 		if filter.Script != nil {
 			switch searchKey.ScriptType {
 			case "lock":
-				if !cellOutput.Type.Equals(filter.Script) {
+				if cellOutput.Type == nil || !cellOutput.Type.Equals(filter.Script) {
 					return false
 				}
+
 				break
 			case "type":
 				if !cellOutput.Lock.Equals(filter.Script) {

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -78,7 +78,7 @@ func TestGetCellsMaxLimit(t *testing.T) {
 	}
 	resp, err := c.GetCells(context.Background(), s, SearchOrderAsc, math.MaxUint32, "")
 	checkError(t, err)
-	assert.Equal(t, 34, len(resp.Objects))
+	assert.Equal(t, 37, len(resp.Objects))
 
 	// Check response when `WithData` == true in request
 	s = &SearchKey{


### PR DESCRIPTION
As 'cellOutput.type' may be nil, calling 'cellOutput.Type.Equals(xxx)' could potentially result in an 'invalid memory address or nil pointer dereference' error."