### PR TITLE
[BREAKING CHANGE] Add `MultisigVersion` `Legacy` and `V2`

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -62,7 +62,7 @@ func decodeShort(payload []byte, network types.Network) (*Address, error) {
 		if argsLen != 20 {
 			return nil, fmt.Errorf("invalid args length %d", argsLen)
 		}
-		scriptType = systemscript.Secp256k1Blake160MultisigAll
+		scriptType = systemscript.Secp256k1Blake160MultisigAllLegacy
 	case 0x02: // anyone_can_pay
 		if argsLen < 20 || argsLen > 22 {
 			return nil, fmt.Errorf("invalid args length %d", argsLen)
@@ -138,7 +138,7 @@ func (a Address) EncodeShort() (string, error) {
 	payload = append(payload, 0x01)
 	if a.Script.CodeHash == systemscript.GetCodeHash(a.Network, systemscript.Secp256k1Blake160SighashAll) {
 		payload = append(payload, 0x00)
-	} else if a.Script.CodeHash == systemscript.GetCodeHash(a.Network, systemscript.Secp256k1Blake160MultisigAll) {
+	} else if a.Script.CodeHash == systemscript.GetCodeHash(a.Network, systemscript.Secp256k1Blake160MultisigAllLegacy) {
 		payload = append(payload, 0x01)
 	} else if a.Script.CodeHash == systemscript.GetCodeHash(a.Network, systemscript.AnyoneCanPay) {
 		payload = append(payload, 0x02)

--- a/collector/builder/builder.go
+++ b/collector/builder/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nervosnetwork/ckb-sdk-go/v2/address"
 	"github.com/nervosnetwork/ckb-sdk-go/v2/collector"
 	"github.com/nervosnetwork/ckb-sdk-go/v2/collector/handler"
+	"github.com/nervosnetwork/ckb-sdk-go/v2/systemscript"
 	"github.com/nervosnetwork/ckb-sdk-go/v2/transaction"
 	"github.com/nervosnetwork/ckb-sdk-go/v2/types"
 )
@@ -33,7 +34,8 @@ func NewSimpleTransactionBuilder(network types.Network) *SimpleTransactionBuilde
 	if network == types.NetworkMain || network == types.NetworkTest || network == types.NetworkPreview {
 		s := SimpleTransactionBuilder{}
 		s.Register(handler.NewSecp256k1Blake160SighashAllScriptHandler(network))
-		s.Register(handler.NewSecp256k1Blake160MultisigAllScriptHandler(network))
+		s.Register(handler.NewSecp256k1Blake160MultisigAllScriptHandler(network, systemscript.MultisigLegacy))
+		s.Register(handler.NewSecp256k1Blake160MultisigAllScriptHandler(network, systemscript.MultisigV2))
 		s.Register(handler.NewSudtScriptHandler(network))
 		s.Register(handler.NewDaoScriptHandler(network))
 		s.Register(handler.NewOmnilockScriptHandler(network))

--- a/collector/example/example.go
+++ b/collector/example/example.go
@@ -122,7 +122,7 @@ func SendCkbFromMultisigAddressExample() error {
 	// ckt1qpw9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn32sqdunqvd3g2felqv6qer8pkydws8jg9qxlca0st5v
 	sender, _ := address.Address{
 		Script: &types.Script{
-			CodeHash: systemscript.GetCodeHash(network, systemscript.Secp256k1Blake160MultisigAll),
+			CodeHash: systemscript.GetCodeHash(network, systemscript.Secp256k1Blake160MultisigAllLegacy),
 			HashType: types.HashTypeType,
 			Args:     args,
 		},

--- a/collector/handler/ckb.go
+++ b/collector/handler/ckb.go
@@ -58,27 +58,46 @@ func (r *Secp256k1Blake160SighashAllScriptHandler) BuildTransaction(builder coll
 }
 
 type Secp256k1Blake160MultisigAllScriptHandler struct {
-	cellDep *types.CellDep
-	network types.Network
+	multisigVersion systemscript.MultisigVersion
+	cellDep         *types.CellDep
+	network         types.Network
 }
 
-func NewSecp256k1Blake160MultisigAllScriptHandler(network types.Network) *Secp256k1Blake160MultisigAllScriptHandler {
+func NewSecp256k1Blake160MultisigAllScriptHandler(network types.Network, multisigVersion systemscript.MultisigVersion) *Secp256k1Blake160MultisigAllScriptHandler {
 	var txHash types.Hash
-	if network == types.NetworkMain {
-		txHash = types.HexToHash("0x71a7ba8fc96349fea0ed3a5c47992e3b4084b031a42264a018e0072e8172e46c")
-	} else if network == types.NetworkTest {
-		txHash = types.HexToHash("0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37")
-	} else if network == types.NetworkPreview {
-		txHash = types.HexToHash("0x0fab65924f2784f17ad7f86d6aef4b04ca1ca237102a68961594acebc5c77816")
+	var index uint32
+	if multisigVersion == systemscript.MultisigLegacy {
+		if network == types.NetworkMain {
+			txHash = types.HexToHash("0x71a7ba8fc96349fea0ed3a5c47992e3b4084b031a42264a018e0072e8172e46c")
+		} else if network == types.NetworkTest {
+			txHash = types.HexToHash("0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37")
+			index = 1
+		} else if network == types.NetworkPreview {
+			txHash = types.HexToHash("0x0fab65924f2784f17ad7f86d6aef4b04ca1ca237102a68961594acebc5c77816")
+			index = 1
+		} else {
+			return nil
+		}
+	} else if multisigVersion == systemscript.MultisigV2 {
+		if network == types.NetworkMain {
+			txHash = types.HexToHash("0x6888aa39ab30c570c2c30d9d5684d3769bf77265a7973211a3c087fe8efbf738")
+			index = 0
+		} else if network == types.NetworkTest {
+			txHash = types.HexToHash("0x2eefdeb21f3a3edf697c28a52601b4419806ed60bb427420455cc29a090b26d5")
+			index = 0
+		} else {
+			return nil
+		}
 	} else {
 		return nil
 	}
 
 	return &Secp256k1Blake160MultisigAllScriptHandler{
+		multisigVersion: multisigVersion,
 		cellDep: &types.CellDep{
 			OutPoint: &types.OutPoint{
 				TxHash: txHash,
-				Index:  1,
+				Index:  index,
 			},
 			DepType: types.DepTypeDepGroup,
 		},
@@ -90,8 +109,19 @@ func (r *Secp256k1Blake160MultisigAllScriptHandler) isMatched(script *types.Scri
 	if script == nil {
 		return false
 	}
-	codeHash := systemscript.GetCodeHash(r.network, systemscript.Secp256k1Blake160MultisigAll)
-	return reflect.DeepEqual(script.CodeHash, codeHash)
+
+	var codeHash types.Hash
+	var scriptHashType types.ScriptHashType
+	if r.multisigVersion == systemscript.MultisigLegacy {
+		codeHash = systemscript.GetCodeHash(r.network, systemscript.Secp256k1Blake160MultisigAllLegacy)
+		scriptHashType = types.HashTypeType
+	} else if r.multisigVersion == systemscript.MultisigV2 {
+		codeHash = systemscript.GetCodeHash(r.network, systemscript.Secp256k1Blake160MultisigAllV2)
+		scriptHashType = types.HashTypeData1
+	} else {
+		return false
+	}
+	return reflect.DeepEqual(script.CodeHash, codeHash) && reflect.DeepEqual(script.HashType, scriptHashType)
 }
 
 func (r *Secp256k1Blake160MultisigAllScriptHandler) BuildTransaction(builder collector.TransactionBuilder, group *transaction.ScriptGroup, context interface{}) (bool, error) {

--- a/systemscript/generator.go
+++ b/systemscript/generator.go
@@ -32,13 +32,24 @@ func Secp256K1Blake160SignhashAllByPublicKey(compressedPubKey []byte) (*types.Sc
 }
 
 // Secp256k1Blake160Multisig generates scep256k1_blake160_multisig script.
-func Secp256k1Blake160Multisig(config *MultisigConfig) (*types.Script, error) {
+func Secp256k1Blake160Multisig(config *MultisigConfig, multisigVersion MultisigVersion) (*types.Script, error) {
 	args := config.Hash160()
 	// secp256k1_blake160_multisig_all share the same code hash in network main and test
-	codeHash := GetCodeHash(types.NetworkTest, Secp256k1Blake160MultisigAll)
+	var codeHash types.Hash
+	var hashType types.ScriptHashType
+	if multisigVersion == MultisigLegacy {
+		codeHash = GetCodeHash(types.NetworkTest, Secp256k1Blake160MultisigAllLegacy)
+		hashType = types.HashTypeType
+	} else if multisigVersion == MultisigV2 {
+		codeHash = GetCodeHash(types.NetworkTest, Secp256k1Blake160MultisigAllV2)
+		hashType = types.HashTypeData1
+	} else {
+		return nil, nil
+	}
+
 	return &types.Script{
 		CodeHash: codeHash,
-		HashType: types.HashTypeType,
+		HashType: hashType,
 		Args:     args,
 	}, nil
 }

--- a/systemscript/generator_test.go
+++ b/systemscript/generator_test.go
@@ -57,7 +57,7 @@ func TestSecp256k1Blake160Multisig(t *testing.T) {
 		}
 		multisigConfig.AddKeyHash(blake2b.Blake256(key))
 	}
-	s, err := Secp256k1Blake160Multisig(multisigConfig)
+	s, err := Secp256k1Blake160Multisig(multisigConfig, MultisigLegacy)
 	if err != nil {
 		t.Error(t, err)
 	}

--- a/systemscript/info.go
+++ b/systemscript/info.go
@@ -15,13 +15,27 @@ type SystemScript uint
 
 const (
 	Secp256k1Blake160SighashAll SystemScript = iota
-	Secp256k1Blake160MultisigAll
+	Secp256k1Blake160MultisigAllLegacy
 	AnyoneCanPay
 	Dao
 	Sudt
 	Cheque
 	PwLock
 	Omnilock
+	Secp256k1Blake160MultisigAllV2
+)
+
+type MultisigVersion uint
+
+const (
+	// Multisig Script deployed on Genesis Block
+	// https://explorer.nervos.org/script/0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8/type
+	MultisigLegacy MultisigVersion = iota
+
+	// Latest multisig script, Enhance multisig handling for optional since value
+	// https://github.com/nervosnetwork/ckb-system-scripts/pull/99
+	// https://explorer.nervos.org/script/0x36c971b8d41fbd94aabca77dc75e826729ac98447b46f91e00796155dddb0d29/data1
+	MultisigV2
 )
 
 var mainnetContracts = make(map[SystemScript]*Info)
@@ -42,12 +56,21 @@ func initMainnetSystemScript() {
 		},
 		DepType: types.DepTypeDepGroup,
 	}
-	mainnetContracts[Secp256k1Blake160MultisigAll] = &Info{
+	mainnetContracts[Secp256k1Blake160MultisigAllLegacy] = &Info{
 		CodeHash: types.HexToHash("0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8"),
 		HashType: types.HashTypeType,
 		OutPoint: &types.OutPoint{
 			TxHash: types.HexToHash("0x71a7ba8fc96349fea0ed3a5c47992e3b4084b031a42264a018e0072e8172e46c"),
 			Index:  1,
+		},
+		DepType: types.DepTypeDepGroup,
+	}
+	mainnetContracts[Secp256k1Blake160MultisigAllV2] = &Info{
+		CodeHash: types.HexToHash("0x36c971b8d41fbd94aabca77dc75e826729ac98447b46f91e00796155dddb0d29"),
+		HashType: types.HashTypeData1,
+		OutPoint: &types.OutPoint{
+			TxHash: types.HexToHash("0x6888aa39ab30c570c2c30d9d5684d3769bf77265a7973211a3c087fe8efbf738"),
+			Index:  0,
 		},
 		DepType: types.DepTypeDepGroup,
 	}
@@ -117,12 +140,21 @@ func initTestnetSystemScript() {
 		},
 		DepType: types.DepTypeDepGroup,
 	}
-	testnetContracts[Secp256k1Blake160MultisigAll] = &Info{
+	testnetContracts[Secp256k1Blake160MultisigAllLegacy] = &Info{
 		CodeHash: types.HexToHash("0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8"),
 		HashType: types.HashTypeType,
 		OutPoint: &types.OutPoint{
 			TxHash: types.HexToHash("0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37"),
 			Index:  1,
+		},
+		DepType: types.DepTypeDepGroup,
+	}
+	testnetContracts[Secp256k1Blake160MultisigAllV2] = &Info{
+		CodeHash: types.HexToHash("0x36c971b8d41fbd94aabca77dc75e826729ac98447b46f91e00796155dddb0d29"),
+		HashType: types.HashTypeData1,
+		OutPoint: &types.OutPoint{
+			TxHash: types.HexToHash("0x2eefdeb21f3a3edf697c28a52601b4419806ed60bb427420455cc29a090b26d5"),
+			Index:  0,
 		},
 		DepType: types.DepTypeDepGroup,
 	}

--- a/systemscript/info_test.go
+++ b/systemscript/info_test.go
@@ -9,8 +9,12 @@ import (
 func TestGetSystemScriptInfo(t *testing.T) {
 	script := GetInfo(types.NetworkMain, Secp256k1Blake160SighashAll)
 	assert.NotNil(t, script)
-	script = GetInfo(types.NetworkMain, Secp256k1Blake160MultisigAll)
+	script = GetInfo(types.NetworkMain, Secp256k1Blake160MultisigAllLegacy)
 	assert.NotNil(t, script)
-	script = GetInfo(types.NetworkTest, Secp256k1Blake160MultisigAll)
+	script = GetInfo(types.NetworkMain, Secp256k1Blake160MultisigAllV2)
+	assert.NotNil(t, script)
+	script = GetInfo(types.NetworkTest, Secp256k1Blake160MultisigAllLegacy)
+	assert.NotNil(t, script)
+	script = GetInfo(types.NetworkTest, Secp256k1Blake160MultisigAllV2)
 	assert.NotNil(t, script)
 }

--- a/transaction/signer/init.go
+++ b/transaction/signer/init.go
@@ -12,7 +12,9 @@ func init() {
 		instance.RegisterLockSigner(
 			systemscript.GetCodeHash(network, systemscript.Secp256k1Blake160SighashAll), &Secp256k1Blake160SighashAllSigner{})
 		instance.RegisterLockSigner(
-			systemscript.GetCodeHash(network, systemscript.Secp256k1Blake160MultisigAll), &Secp256k1Blake160MultisigAllSigner{})
+			systemscript.GetCodeHash(network, systemscript.Secp256k1Blake160MultisigAllLegacy), &Secp256k1Blake160MultisigAllSigner{})
+		instance.RegisterLockSigner(
+			systemscript.GetCodeHash(network, systemscript.Secp256k1Blake160MultisigAllV2), &Secp256k1Blake160MultisigAllSigner{})
 		instance.RegisterLockSigner(
 			systemscript.GetCodeHash(network, systemscript.AnyoneCanPay), &AnyCanPaySigner{})
 		instance.RegisterLockSigner(


### PR DESCRIPTION
This PR add `systemscript.MultisigVersion` param to `func NewSecp256k1Blake160MultisigAllScriptHandler`.
Before:
```go
func NewSecp256k1Blake160MultisigAllScriptHandler(
    network types.Network
) *Secp256k1Blake160MultisigAllScriptHandler {
```
This PR:

```go
type MultisigVersion uint

const (
	// Multisig Script deployed on Genesis Block
	// https://explorer.nervos.org/script/0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8/type
	MultisigLegacy MultisigVersion = iota

	// Latest multisig script, Enhance multisig handling for optional since value
	// https://github.com/nervosnetwork/ckb-system-scripts/pull/99
	// https://explorer.nervos.org/script/0x36c971b8d41fbd94aabca77dc75e826729ac98447b46f91e00796155dddb0d29/data1
	MultisigV2
)


func NewSecp256k1Blake160MultisigAllScriptHandler(
    network types.Network,
    multisigVersion systemscript.MultisigVersion
) *Secp256k1Blake160MultisigAllScriptHandler {
```

Invite @doitian, @zhangsoledad, @driftluo , @quake to review.