### PR TITLE
EntryCompleted fields should be uppercase

### DIFF
--- a/types/pool.go
+++ b/types/pool.go
@@ -100,7 +100,7 @@ type PoolTxDetailInfo struct {
 
 type EntryCompleted struct {
 	// Cached tx cycles
-	cycles uint64 `json:"cycles"`
+	Cycles uint64 `json:"cycles"`
 	// Cached tx fee
-	fee uint64 `json:"fee"`
+	Fee uint64 `json:"fee"`
 }


### PR DESCRIPTION
In Go, fields that start with an uppercase letter are exported (public), while fields that start with a lowercase letter are unexported (private).

@quake 